### PR TITLE
Scoresheets that are waiting for head ref will always be yellow

### DIFF
--- a/apps/frontend/components/audience-display/scoreboard/previous-match.tsx
+++ b/apps/frontend/components/audience-display/scoreboard/previous-match.tsx
@@ -13,25 +13,23 @@ const TeamScoreBox: React.FC<TeamScoreBoxProps> = ({ team, scoresheet }) => {
   return (
     <Stack
       sx={{
-        color:
-          scoresheet.status === 'in-progress'
-            ? yellow[800]
-            : scoresheet.status === 'empty'
-            ? grey[800]
-            : green[800],
+        color: ['in-progress', 'waiting-for-head-ref'].includes(scoresheet.status)
+          ? yellow[800]
+          : scoresheet.status === 'empty'
+          ? grey[800]
+          : green[800],
         border: `1px solid ${
-          scoresheet.status === 'in-progress'
+          ['in-progress', 'waiting-for-head-ref'].includes(scoresheet.status)
             ? yellow[300]
             : scoresheet.status === 'empty'
             ? grey[300]
             : green[300]
         }`,
-        backgroundColor:
-          scoresheet.status === 'in-progress'
-            ? yellow[100]
-            : scoresheet.status === 'empty'
-            ? grey[100]
-            : green[100],
+        backgroundColor: ['in-progress', 'waiting-for-head-ref'].includes(scoresheet.status)
+          ? yellow[100]
+          : scoresheet.status === 'empty'
+          ? grey[100]
+          : green[100],
         borderRadius: '0.5rem',
         px: 1.5,
         py: 0.5


### PR DESCRIPTION
Co-authored-by: WiFi <itamaroryan@users.noreply.github.com>