### PR TITLE
Fix Crash From Users API

### DIFF
--- a/apps/backend/src/routers/api/events/users.ts
+++ b/apps/backend/src/routers/api/events/users.ts
@@ -6,11 +6,7 @@ const router = express.Router({ mergeParams: true });
 
 router.get('/', (req: Request, res: Response) => {
   db.getEventUsers(new ObjectId(req.params.eventId)).then(users => {
-    return Promise.all(
-      users.map(user => {
-        return res.json(user);
-      })
-    );
+    return res.json(users);
   });
 });
 


### PR DESCRIPTION
The previous implemetation of the `/api/events/[eventId]/users` called `res.json` multiple times. This caused the application to try to return multiple responses to the same request thus crashing with the error:
```
Error: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (node:_http_outgoing:652:11)
    at ServerResponse.header (xxxxxx\lems\node_modules\express\lib\response.js:794:10)
    at ServerResponse.send (xxxxxx\lems\node_modules\express\lib\response.js:174:12)
    at ServerResponse.json (xxxxxx\lems\node_modules\express\lib\response.js:278:15)
    at xxxxxx\lems\dist\apps\backend\main.js:1879:24
    at Array.map (<anonymous>)
    at xxxxxx\lems\dist\apps\backend\main.js:1878:34
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```
I changed the implementation to match the [admin api implementation](https://github.com/FIRSTIsrael/lems/blob/8a15ee1929e8095898f0c328eb1c9ad484b657b7/apps/backend/src/routers/api/admin/events/users.ts#L9).