### PR TITLE
CSRF Protection

### DIFF
--- a/apps/backend/src/middlewares/csrf-validator.ts
+++ b/apps/backend/src/middlewares/csrf-validator.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response } from 'express';
+
+const csrfValidator = (req: Request, res: Response, next: NextFunction) => {
+  const contentType = req.get('Content-Type');
+  const csrf = req.get('x-lems-csrf-enabled');
+  if (contentType === 'application/json' || req.method !== "POST" || csrf) {
+    return next();
+  }
+
+  return res.status(403).json({ error: 'FORBIDDEN' });
+};
+
+export default csrfValidator;

--- a/apps/backend/src/routers/api/admin/index.ts
+++ b/apps/backend/src/routers/api/admin/index.ts
@@ -1,12 +1,10 @@
 import express from 'express';
 import adminEventRouter from './events/index';
 import adminValidator from '../../../middlewares/admin-validator';
-import csrfValidator from '../../../middlewares/csrf-validator';
 
 const router = express.Router({ mergeParams: true });
 
 router.use('/', adminValidator);
-router.post('/', csrfValidator);
 
 router.use('/events', adminEventRouter);
 

--- a/apps/backend/src/routers/api/admin/index.ts
+++ b/apps/backend/src/routers/api/admin/index.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import adminEventRouter from './events/index';
 import adminValidator from '../../../middlewares/admin-validator';
+import csrfValidator from '../../../middlewares/csrf-validator';
 
 const router = express.Router({ mergeParams: true });
 
 router.use('/', adminValidator);
+router.post('/', csrfValidator);
 
 router.use('/events', adminEventRouter);
 

--- a/apps/backend/src/routers/api/index.ts
+++ b/apps/backend/src/routers/api/index.ts
@@ -2,10 +2,12 @@ import express from 'express';
 import { authMiddleware } from '../../middlewares/auth';
 import eventsRouter from './events/index';
 import adminRouter from './admin/index';
+import csrfValidator from '../../middlewares/csrf-validator';
 
 const router = express.Router({ mergeParams: true });
 
 router.use('/', authMiddleware);
+router.use('/', csrfValidator);
 
 router.use('/admin', adminRouter);
 router.use('/events', eventsRouter);

--- a/apps/frontend/components/general/upload-file.tsx
+++ b/apps/frontend/components/general/upload-file.tsx
@@ -52,7 +52,8 @@ const UploadFileButton: React.FC<UploadFileButtonProps> = ({
     formData.append('file', file);
     apiFetch(urlPath, {
       method: 'POST',
-      body: formData
+      body: formData,
+      headers: {'x-lems-csrf-enabled': "true"}
     })
       .then(res => {
         if (res?.ok) {


### PR DESCRIPTION
Added CSRF protection with minimal changes to the code.

The protection has two components:
1. Blocking non `application/json` requests to the API. See [Disallowing non-simple requests](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#disallowing-non-simple-requests)
2. For file upload (`<form>`), add a custom header. See [Employing Custom Request Headers for AJAX/API](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#employing-custom-request-headers-for-ajaxapi)

Note that I didn't add CSRF protection to the dashboard. The frontend source code needs to be modified to include the custom header, and I do not have access to the dashboard code.

I have tested uploading files and accessing the API for both the admin and regular APIs