### PR TITLE
Fix Scores Sorting

### DIFF
--- a/apps/backend/src/routers/api/events/export.ts
+++ b/apps/backend/src/routers/api/events/export.ts
@@ -5,6 +5,7 @@ import { Parser, FieldInfo } from '@json2csv/plainjs';
 import * as db from '@lems/database';
 import { JudgingCategory } from '@lems/types';
 import { rubricsSchemas, RubricSchemaSection, RubricsSchema } from '@lems/season';
+import { compareScoreArrays } from '@lems/utils/arrays';
 
 const router = express.Router({ mergeParams: true });
 
@@ -111,7 +112,13 @@ router.get(
       };
     });
 
-    csvData.sort((a, b) => b.highestScore - a.highestScore);
+    const flattenScores = row => {
+      return Object.keys(row)
+        .filter(key => key.startsWith('round-'))
+        .map(key => row[key]);
+    };
+
+    csvData.sort((a, b) => compareScoreArrays(flattenScores(a), flattenScores(b)));
 
     res.set('Content-Disposition', `attachment; filename=scores.csv`);
     res.set('Content-Type', 'text/csv');

--- a/apps/frontend/components/audience-display/scoreboard/scores.tsx
+++ b/apps/frontend/components/audience-display/scoreboard/scores.tsx
@@ -14,6 +14,7 @@ import RemoveIcon from '@mui/icons-material/Remove';
 import { WithId } from 'mongodb';
 import { localizedMatchStage } from '../../../localization/field';
 import { localizeTeam } from '../../../localization/teams';
+import { compareScoreArrays } from '@lems/utils/arrays';
 
 interface ScoreboardScoresProps {
   scoresheets: Array<WithId<Scoresheet>>;
@@ -36,19 +37,20 @@ const ScoreboardScores: React.FC<ScoreboardScoresProps> = ({ scoresheets, teams,
 
   const maxScores = teams
     .map(t => {
+      const scores = [
+        ...scoresheets
+          .filter(
+            s => s.teamId === t._id && s.stage === eventState.currentStage && s.status === 'ready'
+          )
+          .map(s => s.data?.score || 0)
+      ];
       return {
         team: t,
-        score: Math.max(
-          ...scoresheets
-            .filter(
-              s => s.teamId === t._id && s.stage === eventState.currentStage && s.status === 'ready'
-            )
-            .map(s => s.data?.score || 0),
-          0
-        )
+        scores: scores,
+        score: Math.max(...scores, 0)
       };
     })
-    .sort((a, b) => b.score - a.score);
+    .sort((a, b) => compareScoreArrays(a.scores, b.scores));
 
   const marquee = keyframes`
     from {transform: translateY(0)}

--- a/apps/frontend/pages/event/[eventId]/reports/scoreboard.tsx
+++ b/apps/frontend/pages/event/[eventId]/reports/scoreboard.tsx
@@ -14,6 +14,7 @@ import { apiFetch, serverSideGetRequests } from '../../../../lib/utils/fetch';
 import { localizedMatchStage } from '../../../../localization/field';
 import { localizedRoles } from '../../../../localization/roles';
 import { localizeTeam } from '../../../../localization/teams';
+import { compareScoreArrays } from '@lems/utils/arrays';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -118,7 +119,7 @@ const Page: NextPage<Props> = ({
       max: Math.max(...row.scores.map(score => score || 0))
     }));
 
-    teamsWithMaxScores.sort((a, b) => b.max - a.max);
+    teamsWithMaxScores.sort((a,b) => compareScoreArrays(a.scores,b.scores));
 
     const dataGridRows = teamsWithMaxScores.map((row, index) => ({
       rank: index + 1,

--- a/libs/utils/arrays/src/lib/utils-arrays.ts
+++ b/libs/utils/arrays/src/lib/utils-arrays.ts
@@ -8,3 +8,19 @@ export const reorder = (arr: Array<any>, startIndex: number, endIndex: number) =
   result.splice(endIndex, 0, removed);
   return result;
 };
+
+export const compareScoreArrays = (
+  scoresA: (number | undefined)[],
+  scoresB: (number | undefined)[]
+) => {
+  const sortedA = [...scoresA].sort((a, b) => (b || 0) - (a || 0));
+  const sortedB = [...scoresB].sort((a, b) => (b || 0) - (a || 0));
+  const maxLen = Math.max(scoresA.length, scoresB.length);
+
+  let difference = 0;
+  // iterate over the scores until we find a difference
+  for (let i = 0; i < maxLen && difference == 0; i++) {
+    difference = (sortedB[i] || 0) - (sortedA[i] || 0);
+  }
+  return difference;
+};


### PR DESCRIPTION
Made the scores sort by highest, 2nd highest...

Implemented this change in the audience display, csv export, and score report.

The current implementation does not take into account the team number. We can implement that after the season as it will require some more complexity.