### PR TITLE
Cv form now has team select

### DIFF
--- a/apps/backend/src/routers/api/divisions/insights/team.ts
+++ b/apps/backend/src/routers/api/divisions/insights/team.ts
@@ -127,7 +127,7 @@ router.get(
             {
               $lookup: {
                 from: 'core-values-forms',
-                let: { divisionId: '$divisionId', teamNumber: '$number' },
+                let: { divisionId: '$divisionId', teamId: '$_id' },
                 pipeline: [
                   {
                     $match: {
@@ -137,7 +137,7 @@ router.get(
                             $eq: ['$divisionId', '$$divisionId']
                           },
                           {
-                            $eq: ['$demonstratorAffiliation', { $toString: '$$teamNumber' }]
+                            $eq: ['$demonstratorAffiliation._id', '$$teamId']
                           }
                         ]
                       }

--- a/apps/backend/src/websocket/handlers/judging.ts
+++ b/apps/backend/src/websocket/handlers/judging.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import { WithId, ObjectId } from 'mongodb';
 import * as scheduler from 'node-schedule';
 import * as db from '@lems/database';
-import { JUDGING_SESSION_LENGTH, Award, Team, AwardNames } from '@lems/types';
+import { JUDGING_SESSION_LENGTH, Award, Team, AwardNames, CoreValuesForm } from '@lems/types';
 
 export const handleStartSession = async (
   namespace: any,
@@ -268,6 +268,10 @@ export const handleUpdateRubric = async (
 
 export const handleCreateCvForm = async (namespace: any, divisionId: string, content, callback) => {
   console.log(`📄 Creating Core Values Form in division ${divisionId}`);
+  const { observerAffiliation, demonstratorAffiliation } = content as Partial<CoreValuesForm>;
+  if (observerAffiliation) content.observerAffiliation._id = new ObjectId(observerAffiliation._id);
+  if (demonstratorAffiliation)
+    content.demonstratorAffiliation._id = new ObjectId(demonstratorAffiliation._id);
   const cvFormId = await db
     .addCoreValuesForm({ ...content, divisionId: new ObjectId(divisionId) })
     .then(result => result.insertedId);
@@ -294,6 +298,11 @@ export const handleUpdateCvForm = async (
   }
 
   console.log(`🖊️ Updating core values form ${cvFormId} in division ${divisionId}`);
+
+  const { observerAffiliation, demonstratorAffiliation } = content as Partial<CoreValuesForm>;
+  if (observerAffiliation) content.observerAffiliation._id = new ObjectId(observerAffiliation._id);
+  if (demonstratorAffiliation)
+    content.demonstratorAffiliation._id = new ObjectId(demonstratorAffiliation._id);
 
   await db.updateCoreValuesForm(
     { _id: cvForm._id },

--- a/apps/frontend/components/cv-form/cv-form-card.tsx
+++ b/apps/frontend/components/cv-form/cv-form-card.tsx
@@ -32,11 +32,15 @@ const CVFormCard: React.FC<CVFormCardProps> = ({ division, form }) => {
         }
         title={`דיווח על ${form.demonstrators
           .map(d =>
-            d === 'team' ? `קבוצה #${form.demonstratorAffiliation}` : localizedFormSubject[d]
+            d === 'team'
+              ? `קבוצה #${form.demonstratorAffiliation?.number}`
+              : localizedFormSubject[d]
           )
           .join(', ')}`}
         subheader={`האירוע נצפה על ידי ${form.observers
-          .map(o => (o === 'team' ? `קבוצה #${form.observerAffiliation}` : localizedFormSubject[o]))
+          .map(o =>
+            o === 'team' ? `קבוצה #${form.observerAffiliation?.number}` : localizedFormSubject[o]
+          )
           .join(', ')}`}
       />
       <CardContent>

--- a/apps/frontend/components/cv-form/cv-form-header.tsx
+++ b/apps/frontend/components/cv-form/cv-form-header.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { WithId } from 'mongodb';
-import { FastField, FieldProps, FormikValues } from 'formik';
-import { AutocompleteRenderInputParams, Typography } from '@mui/material';
+import { FormikValues } from 'formik';
+import { Typography } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import { Team } from '@lems/types';
 import CVFormSubjectSelect from './cv-form-subject';
-import TeamSelection from '../general/team-selection';
 import FormikTeamField from '../general/forms/formik-team-field';
 
 interface CVFormHeaderProps {

--- a/apps/frontend/components/cv-form/cv-form-header.tsx
+++ b/apps/frontend/components/cv-form/cv-form-header.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
+import { WithId } from 'mongodb';
 import { FastField, FieldProps, FormikValues } from 'formik';
-import { Typography, TextField } from '@mui/material';
+import { AutocompleteRenderInputParams, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid2';
+import { Team } from '@lems/types';
 import CVFormSubjectSelect from './cv-form-subject';
+import TeamSelection from '../general/team-selection';
+import FormikTeamField from '../general/forms/formik-team-field';
 
 interface CVFormHeaderProps {
+  teams: Array<WithId<Team>>;
   values: FormikValues;
   readOnly?: boolean;
 }
 
-const CVFormHeader: React.FC<CVFormHeaderProps> = ({ values, readOnly }) => {
+const CVFormHeader: React.FC<CVFormHeaderProps> = ({ teams, values, readOnly }) => {
   return (
     <Grid container spacing={2} sx={{ my: 2 }}>
       <Grid
@@ -49,23 +54,11 @@ const CVFormHeader: React.FC<CVFormHeaderProps> = ({ values, readOnly }) => {
             </Grid>
             {values[subjectType].includes('team') && (
               <Grid sx={{ display: 'flex' }} size={6}>
-                <FastField name={`${subjectType.slice(0, -1)}Affiliation`}>
-                  {({ field, form }: FieldProps) => (
-                    <TextField
-                      fullWidth
-                      label="מספר קבוצה"
-                      sx={{
-                        '& .MuiInputBase-root': {
-                          height: '100%'
-                        }
-                      }}
-                      {...field}
-                      value={field.value}
-                      InputProps={{ readOnly }}
-                      onChange={e => form.setFieldValue(field.name, e.target.value)}
-                    />
-                  )}
-                </FastField>
+                <FormikTeamField
+                  teams={teams}
+                  name={`${subjectType.slice(0, -1)}Affiliation`}
+                  fullWidth
+                />
               </Grid>
             )}
           </React.Fragment>

--- a/apps/frontend/components/cv-form/cv-form.tsx
+++ b/apps/frontend/components/cv-form/cv-form.tsx
@@ -1,6 +1,6 @@
 import { Form, Formik, FormikValues } from 'formik';
 import { Socket } from 'socket.io-client';
-import { WithId } from 'mongodb';
+import { ObjectId, WithId } from 'mongodb';
 import { enqueueSnackbar } from 'notistack';
 import {
   Table,
@@ -25,7 +25,8 @@ import {
   Division,
   WSClientEmittedEvents,
   WSServerEmittedEvents,
-  SafeUser
+  SafeUser,
+  Team
 } from '@lems/types';
 import { fullMatch } from '@lems/utils/objects';
 import { cvFormSchema } from '@lems/season';
@@ -36,6 +37,7 @@ import CVFormCategoryRow from './cv-form-category-row';
 interface CVFormProps {
   user: WithId<SafeUser>;
   division: WithId<Division>;
+  teams: Array<WithId<Team>>;
   socket: Socket<WSServerEmittedEvents, WSClientEmittedEvents>;
   cvForm?: WithId<CoreValuesForm>;
   readOnly?: boolean;
@@ -45,6 +47,7 @@ interface CVFormProps {
 const CVForm: React.FC<CVFormProps> = ({
   user,
   division,
+  teams,
   socket,
   cvForm: initialCvForm,
   readOnly = false,
@@ -58,9 +61,9 @@ const CVForm: React.FC<CVFormProps> = ({
   const getEmptyCVForm = () => {
     const divisionId = division._id;
     const observers: Array<CVFormSubject> = [];
-    const observerAffiliation = '';
+    const observerAffiliation: WithId<Team> | null = null;
     const demonstrators: Array<CVFormSubject> = [];
-    const demonstratorAffiliation = '';
+    const demonstratorAffiliation: WithId<Team> | null = null;
     const data: { [key in CVFormCategoryNames]: CVFormCategory } = {} as {
       [key in CVFormCategoryNames]: CVFormCategory;
     };
@@ -223,7 +226,7 @@ const CVForm: React.FC<CVFormProps> = ({
     >
       {({ values, isValid, submitForm }) => (
         <Form>
-          <CVFormHeader values={values} readOnly={readOnly} />
+          <CVFormHeader teams={teams} values={values} readOnly={readOnly} />
           <TableContainer component={Paper} sx={{ mt: 4, height: 600, overflowY: 'scroll' }}>
             <Table stickyHeader>
               <TableHead>

--- a/apps/frontend/components/cv-form/cv-panel.tsx
+++ b/apps/frontend/components/cv-form/cv-panel.tsx
@@ -9,19 +9,21 @@ import {
   CoreValuesForm,
   Division,
   WSClientEmittedEvents,
-  WSServerEmittedEvents
+  WSServerEmittedEvents,
+  Team
 } from '@lems/types';
 import CVFormCard from './cv-form-card';
 import CVForm from './cv-form';
 
 interface CVPanelProps {
   user: WithId<SafeUser>;
+  teams: Array<WithId<Team>>;
   cvForms: Array<WithId<CoreValuesForm>>;
   division: WithId<Division>;
   socket: Socket<WSServerEmittedEvents, WSClientEmittedEvents>;
 }
 
-const CVPanel: React.FC<CVPanelProps> = ({ user, cvForms, division, socket }) => {
+const CVPanel: React.FC<CVPanelProps> = ({ user, teams, cvForms, division, socket }) => {
   const [newForm, setNewForm] = useState<boolean>(false);
   return (
     <>
@@ -29,6 +31,7 @@ const CVPanel: React.FC<CVPanelProps> = ({ user, cvForms, division, socket }) =>
         <CVForm
           user={user}
           division={division}
+          teams={teams.filter(team => team.registered)}
           socket={socket}
           onSubmit={() => setNewForm(false)}
         />

--- a/apps/frontend/components/general/forms/formik-team-field.tsx
+++ b/apps/frontend/components/general/forms/formik-team-field.tsx
@@ -1,0 +1,47 @@
+import { WithId } from 'mongodb';
+import { Field, FieldProps } from 'formik';
+import { Autocomplete, AutocompleteProps, TextField } from '@mui/material';
+import { Team } from '@lems/types';
+import { localizeTeam } from '../../../localization/teams';
+
+type FormikTeamFieldProps = {
+  teams: Array<WithId<Team>>;
+  numberOnly?: boolean;
+  name: string;
+  label?: string;
+} & Partial<AutocompleteProps<WithId<Team> | null, false, false, false>>;
+
+const FormikTeamField: React.FC<FormikTeamFieldProps> = ({
+  name,
+  label,
+  teams,
+  numberOnly = false,
+  ...props
+}) => {
+  return (
+    <Field name={name}>
+      {({ field, form }: FieldProps) => (
+        <Autocomplete<WithId<Team> | null, false, false, false>
+          {...props}
+          {...field}
+          blurOnSelect
+          options={teams}
+          getOptionLabel={team =>
+            typeof team !== 'string' && team
+              ? numberOnly
+                ? team.number.toString()
+                : localizeTeam(team)
+              : ''
+          }
+          inputMode="search"
+          value={field.value}
+          onChange={(_e, value) => form.setFieldValue(name, value)}
+          renderInput={params => <TextField {...params} label="קבוצה" />}
+          multiple={false}
+        />
+      )}
+    </Field>
+  );
+};
+
+export default FormikTeamField;

--- a/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
+++ b/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
@@ -4,7 +4,7 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { enqueueSnackbar } from 'notistack';
 import { Paper } from '@mui/material';
-import { CoreValuesForm, DivisionWithEvent, SafeUser } from '@lems/types';
+import { CoreValuesForm, DivisionWithEvent, SafeUser, Team } from '@lems/types';
 import ConnectionIndicator from '../../../components/connection-indicator';
 import { useWebsocket } from '../../../hooks/use-websocket';
 import Layout from '../../../components/layout';
@@ -15,11 +15,12 @@ import { localizeDivisionTitle } from '../../../localization/event';
 
 interface Props {
   user: WithId<SafeUser>;
+  teams: Array<WithId<Team>>;
   division: WithId<DivisionWithEvent>;
   cvForm: WithId<CoreValuesForm>;
 }
 
-const Page: NextPage<Props> = ({ user, division, cvForm: initialCvForm }) => {
+const Page: NextPage<Props> = ({ user, teams, division, cvForm: initialCvForm }) => {
   const router = useRouter();
   const [cvForm, setCvForm] = useState<WithId<CoreValuesForm>>(initialCvForm);
 
@@ -58,6 +59,7 @@ const Page: NextPage<Props> = ({ user, division, cvForm: initialCvForm }) => {
           <CVForm
             user={user}
             division={division}
+            teams={teams.filter(team => team.registered)}
             socket={socket}
             cvForm={cvForm}
             readOnly={true}
@@ -76,6 +78,7 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
     const data = await serverSideGetRequests(
       {
         division: `/api/divisions/${divisionId}?withEvent=true`,
+        teams: `/api/divisions/${divisionId}/teams`,
         cvForm: `/api/divisions/${divisionId}/cv-forms/${ctx.params?.cvFormId}`
       },
       ctx

--- a/apps/frontend/pages/lems/tournament-manager.tsx
+++ b/apps/frontend/pages/lems/tournament-manager.tsx
@@ -262,7 +262,13 @@ const Page: NextPage<Props> = ({
             />
           </TabPanel>
           <TabPanel value="5">
-            <CVPanel user={user} cvForms={cvForms} division={division} socket={socket} />
+            <CVPanel
+              user={user}
+              teams={teams}
+              cvForms={cvForms}
+              division={division}
+              socket={socket}
+            />
           </TabPanel>
         </TabContext>
       </Layout>

--- a/libs/types/src/lib/schemas/core-values-form.ts
+++ b/libs/types/src/lib/schemas/core-values-form.ts
@@ -1,4 +1,5 @@
-import { ObjectId } from 'mongodb';
+import { ObjectId, WithId } from 'mongodb';
+import { Team } from './team';
 
 export const CVFormSubjectTypes = [
   'team',
@@ -40,9 +41,9 @@ export interface CVFormCategory {
 export interface CoreValuesForm {
   divisionId: ObjectId;
   observers: Array<CVFormSubject>;
-  observerAffiliation?: string;
+  observerAffiliation?: WithId<Team> | null;
   demonstrators: Array<CVFormSubject>;
-  demonstratorAffiliation?: string;
+  demonstratorAffiliation?: WithId<Team> | null;
   data: { [key in CVFormCategoryNames]: CVFormCategory };
   details: string;
   completedBy: CVFormAuthor;


### PR DESCRIPTION
## Description

This feature allows tournament managers and judge advisors to select teams in CV forms

Closes #733 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![image](https://github.com/user-attachments/assets/b709a172-e868-4f80-bae0-7ff68f092e50)

![image](https://github.com/user-attachments/assets/4610dea6-5cb3-446e-a14d-b2f36aa1a846)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
