### PR TITLE
Fixed admin crashes on normal pages

### DIFF
--- a/apps/backend/src/routers/dashboard/divisions/teams/export.ts
+++ b/apps/backend/src/routers/dashboard/divisions/teams/export.ts
@@ -25,7 +25,9 @@ router.get(
       return;
     }
 
-    const pdf = await getLemsWebpageAsPdf(`/lems/export/${team._id}/rubrics`);
+    const pdf = await getLemsWebpageAsPdf(
+      `/lems/export/${team._id}/rubrics?divisionId=${team.divisionId}`
+    );
 
     res.contentType('application/pdf');
     res.send(pdf);
@@ -45,7 +47,7 @@ router.get(
     }
 
     const pdf = await getLemsWebpageAsPdf(
-      `/lems/${team.divisionId}/export/${team._id}/scoresheets`
+      `/lems/export/${team._id}/scoresheets?divisionId=${team.divisionId}`
     );
 
     res.contentType('application/pdf');

--- a/apps/frontend/lib/utils/fetch.ts
+++ b/apps/frontend/lib/utils/fetch.ts
@@ -1,6 +1,6 @@
-import { ObjectId, WithId } from 'mongodb';
+import { WithId } from 'mongodb';
 import { GetServerSidePropsContext } from 'next';
-import { Division } from '@lems/types';
+import { Division, SafeUser } from '@lems/types';
 
 export const getApiBase = (forceClient = false) => {
   const isSsr = !forceClient && typeof window === 'undefined';
@@ -34,21 +34,31 @@ export const apiFetch = (
 };
 
 export const getUserAndDivision = async (ctx: GetServerSidePropsContext) => {
-  const user = await apiFetch(`/api/me`, undefined, ctx).then(res => res?.json());
+  const user: SafeUser = await apiFetch(`/api/me`, undefined, ctx).then(res => res?.json());
   const divisions: Array<WithId<Division>> = await apiFetch(`/public/divisions`).then(res =>
     res?.json()
   );
-  let divisionId = user.divisionId;
-  if (!divisionId && user.eventId && user.assignedDivisions.length > 0) {
-    const idFromQuery = (ctx.query.divisionId as string) || undefined;
-    if (user.assignedDivisions.includes(idFromQuery)) {
-      divisionId = idFromQuery;
-    } else {
-      divisionId = user.assignedDivisions.filter(
-        (id: ObjectId) => divisions.find(d => d._id === id)?.hasState
-      )[0];
-    }
+
+  let divisionId = user.divisionId?.toString();
+  if (divisionId) return { user, divisionId };
+
+  const isEventUser = (user.eventId && (user.assignedDivisions?.length || 0) > 0) || user.isAdmin;
+  if (!isEventUser) return { user, divisionId };
+
+  const idFromQuery = (ctx.query.divisionId as string) || undefined;
+  const assignedDivisions = user.isAdmin
+    ? divisions.map(d => d._id.toString())
+    : user.assignedDivisions?.map(id => id.toString()) || [];
+
+  if (!idFromQuery) {
+    divisionId = assignedDivisions
+      .find(id => divisions.find(d => d._id.toString() === id)?.hasState)
+      ?.toString();
+    return { user, divisionId };
   }
+
+  const canAccessDivision = assignedDivisions.includes(idFromQuery);
+  if (canAccessDivision) divisionId = idFromQuery;
   return { user, divisionId };
 };
 
@@ -56,6 +66,7 @@ export const serverSideGetRequests = async (
   toFetch: { [key: string]: string },
   ctx: GetServerSidePropsContext
 ) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: { [key: string]: any } = {};
 
   await Promise.all(

--- a/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
+++ b/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/router';
 import { enqueueSnackbar } from 'notistack';
 import { Paper } from '@mui/material';
 import { CoreValuesForm, DivisionWithEvent, SafeUser, Team } from '@lems/types';
-import ConnectionIndicator from '../../../components/connection-indicator';
 import { useWebsocket } from '../../../hooks/use-websocket';
 import Layout from '../../../components/layout';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
@@ -50,9 +49,11 @@ const Page: NextPage<Props> = ({ user, teams, division, cvForm: initialCvForm })
       <Layout
         maxWidth="md"
         title={`טופס ערכי ליבה | ${localizeDivisionTitle(division)}`}
-        action={<ConnectionIndicator status={connectionStatus} />}
+        connectionStatus={connectionStatus}
         back={`/lems/${user.role}`}
         backDisabled={connectionStatus === 'connecting'}
+        user={user}
+        division={division}
         color={division.color}
       >
         <Paper sx={{ p: 4, my: 2 }}>

--- a/apps/frontend/pages/lems/deliberations/category/[judgingCategory].tsx
+++ b/apps/frontend/pages/lems/deliberations/category/[judgingCategory].tsx
@@ -23,7 +23,6 @@ import { fullMatch } from '@lems/utils/objects';
 import { localizedJudgingCategory, makeCvValuesForRubric } from '@lems/season';
 import { RoleAuthorizer } from '../../../../components/role-authorizer';
 import Layout from '../../../../components/layout';
-import ConnectionIndicator from '../../../../components/connection-indicator';
 import { getUserAndDivision, serverSideGetRequests } from '../../../../lib/utils/fetch';
 import { useWebsocket } from '../../../../hooks/use-websocket';
 import { DeliberationTeam } from '../../../../hooks/use-deliberation-teams';
@@ -244,8 +243,9 @@ const Page: NextPage<Props> = ({
         maxWidth={1900}
         back={`/lems/${user.role}`}
         title={`דיון תחום ${localizedJudgingCategory[category].name} | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={<ConnectionIndicator status={connectionStatus} />}
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         color={division.color}
       >
         <Deliberation

--- a/apps/frontend/pages/lems/deliberations/compare.tsx
+++ b/apps/frontend/pages/lems/deliberations/compare.tsx
@@ -32,7 +32,6 @@ import {
 import { localizedJudgingCategory } from '@lems/season';
 import Layout from '../../../components/layout';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
-import ConnectionIndicator from '../../../components/connection-indicator';
 import CompareView from '../../../components/deliberations/compare/compare-view';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
 import { useWebsocket } from '../../../hooks/use-websocket';
@@ -97,7 +96,9 @@ const Page: NextPage<Props> = ({
         maxWidth={1900}
         back={`/lems/${user.role}`}
         title={`השוואת קבוצות | ${localizeDivisionTitle(division)}`}
-        action={<ConnectionIndicator status={connectionStatus} />}
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         color={division.color}
       >
         <Paper sx={{ mb: 2, width: '100%', position: 'sticky', top: 70, zIndex: 10 }}>
@@ -116,6 +117,8 @@ const Page: NextPage<Props> = ({
                 disabled={!selectedTeam}
                 sx={{ width: 36, height: 36 }}
                 onClick={() => {
+                  // Button is disabled if selectedTeam is null
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   addTeam(selectedTeam!._id);
                   setSelectedTeam(null);
                 }}

--- a/apps/frontend/pages/lems/deliberations/final.tsx
+++ b/apps/frontend/pages/lems/deliberations/final.tsx
@@ -24,7 +24,6 @@ import {
 } from '@lems/types';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
 import Layout from '../../../components/layout';
-import ConnectionIndicator from '../../../components/connection-indicator';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
 import { useWebsocket } from '../../../hooks/use-websocket';
 import ChampionsDeliberationLayout from '../../../components/deliberations/final/champions/champions-deliberation-layout';
@@ -380,8 +379,9 @@ const Page: NextPage<Props> = ({
         maxWidth={1900}
         back={`/lems/${user.role}`}
         title={`דיון סופי | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={<ConnectionIndicator status={connectionStatus} />}
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         color={division.color}
       >
         <Deliberation

--- a/apps/frontend/pages/lems/export/[teamId]/rubrics.tsx
+++ b/apps/frontend/pages/lems/export/[teamId]/rubrics.tsx
@@ -36,6 +36,7 @@ import HeaderRow from '../../../../components/judging/rubrics/header-row';
 import TitleRow from '../../../../components/judging/rubrics/title-row';
 import { RoleAuthorizer } from '../../../../components/role-authorizer';
 import { localizeDivisionTitle } from '../../../../localization/event';
+import { getUserAndDivision } from '../../../../lib/utils/fetch';
 
 interface ExportRubricPageProps {
   division: WithId<DivisionWithEvent>;
@@ -286,18 +287,19 @@ const Page: NextPage<Props> = ({ user, division, team, rubrics }) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async ctx => {
+  const { user, divisionId } = await getUserAndDivision(ctx);
+
   try {
     const data = await serverSideGetRequests(
       {
-        user: '/api/me',
-        division: `/api/divisions/${ctx.params?.divisionId}?withEvent=true`,
-        team: `/api/divisions/${ctx.params?.divisionId}/teams/${ctx.params?.teamId}`,
-        rubrics: `/api/divisions/${ctx.params?.divisionId}/teams/${ctx.params?.teamId}/rubrics`
+        division: `/api/divisions/${divisionId}?withEvent=true`,
+        team: `/api/divisions/${divisionId}/teams/${ctx.params?.teamId}`,
+        rubrics: `/api/divisions/${divisionId}/teams/${ctx.params?.teamId}/rubrics`
       },
       ctx
     );
 
-    return { props: { ...data } };
+    return { props: { user, ...data } };
   } catch {
     return { redirect: { destination: '/login', permanent: false } };
   }

--- a/apps/frontend/pages/lems/export/[teamId]/scoresheets.tsx
+++ b/apps/frontend/pages/lems/export/[teamId]/scoresheets.tsx
@@ -25,6 +25,7 @@ import Markdown from 'react-markdown';
 import CustomNumberInput from '../../../../components/field/scoresheet/number-input';
 import { RoleAuthorizer } from '../../../../components/role-authorizer';
 import { localizeDivisionTitle } from '../../../../localization/event';
+import { getUserAndDivision } from '../../../../lib/utils/fetch';
 
 interface ExportMissionClauseProps {
   scoresheet: WithId<Scoresheet>;
@@ -273,13 +274,14 @@ const Page: NextPage<Props> = ({ user, division, team, scoresheets }) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async ctx => {
+  const { user, divisionId } = await getUserAndDivision(ctx);
+
   try {
     const data = await serverSideGetRequests(
       {
-        user: '/api/me',
-        division: `/api/divisions/${ctx.params?.divisionId}?withEvent=true`,
-        team: `/api/divisions/${ctx.params?.divisionId}/teams/${ctx.params?.teamId}`,
-        scoresheets: `/api/divisions/${ctx.params?.divisionId}/teams/${ctx.params?.teamId}/scoresheets`
+        division: `/api/divisions/${divisionId}?withEvent=true`,
+        team: `/api/divisions/${divisionId}/teams/${ctx.params?.teamId}`,
+        scoresheets: `/api/divisions/${divisionId}/teams/${ctx.params?.teamId}/scoresheets`
       },
       ctx
     );
@@ -287,7 +289,7 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
       (scoresheet: Scoresheet) => scoresheet.stage !== 'practice'
     );
 
-    return { props: { ...data } };
+    return { props: { user, ...data } };
   } catch {
     return { redirect: { destination: '/login', permanent: false } };
   }

--- a/apps/frontend/pages/lems/head-queuer.tsx
+++ b/apps/frontend/pages/lems/head-queuer.tsx
@@ -15,8 +15,6 @@ import {
   DivisionWithEvent
 } from '@lems/types';
 import { useWebsocket } from '../../hooks/use-websocket';
-import ConnectionIndicator from '../../components/connection-indicator';
-import ReportLink from '../../components/general/report-link';
 import ActiveMatch from '../../components/field/scorekeeper/active-match';
 import Layout from '../../components/layout';
 import { RoleAuthorizer } from '../../components/role-authorizer';
@@ -142,13 +140,9 @@ const Page: NextPage<Props> = ({
     >
       <Layout
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)} | מתחם ${localizedDivisionSection[user.roleAssociation?.value as string].name}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            <ReportLink />
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         color={division.color}
       >
         {user.roleAssociation?.value === 'field' && (

--- a/apps/frontend/pages/lems/head-referee.tsx
+++ b/apps/frontend/pages/lems/head-referee.tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { WithId } from 'mongodb';
 import { enqueueSnackbar } from 'notistack';
-import { Paper, Stack, Typography } from '@mui/material';
+import { Paper, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import {
   SafeUser,
@@ -15,10 +15,7 @@ import {
   DivisionWithEvent
 } from '@lems/types';
 import { RoleAuthorizer } from '../../components/role-authorizer';
-import ConnectionIndicator from '../../components/connection-indicator';
 import Layout from '../../components/layout';
-import ReportLink from '../../components/general/report-link';
-import InsightsLink from '../../components/general/insights-link';
 import WelcomeHeader from '../../components/general/welcome-header';
 import { getUserAndDivision, serverSideGetRequests } from '../../lib/utils/fetch';
 import { localizedRoles } from '../../localization/roles';
@@ -187,13 +184,10 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth="lg"
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {divisionState.completed ? <InsightsLink /> : <ReportLink />}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
+        divisionState={divisionState}
         color={division.color}
       >
         <WelcomeHeader division={division} user={user} />

--- a/apps/frontend/pages/lems/insights.tsx
+++ b/apps/frontend/pages/lems/insights.tsx
@@ -4,13 +4,7 @@ import { WithId } from 'mongodb';
 import { enqueueSnackbar } from 'notistack';
 import { Tabs, Tab, Paper } from '@mui/material';
 import { TabContext, TabPanel } from '@mui/lab';
-import {
-  DivisionWithEvent,
-  DivisionState,
-  SafeUser,
-  Team,
-  EventUserAllowedRoles
-} from '@lems/types';
+import { DivisionWithEvent, DivisionState, SafeUser, Team } from '@lems/types';
 import Layout from '../../components/layout';
 import { RoleAuthorizer } from '../../components/role-authorizer';
 import FieldInsightsDashboard from '../../components/insights/dashboards/field';
@@ -19,7 +13,6 @@ import { getUserAndDivision, serverSideGetRequests } from '../../lib/utils/fetch
 import GeneralInsightsDashboard from '../../components/insights/dashboards/general';
 import { useQueryParam } from '../../hooks/use-query-param';
 import { localizeDivisionTitle } from '../../localization/event';
-import DivisionDropdown from '../../components/general/division-dropdown';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -50,11 +43,8 @@ const Page: NextPage<Props> = ({ user, division, divisionState, teams }) => {
         title={`ממשק ניתוח תחרות | ${localizeDivisionTitle(division)}`}
         back={`/lems/${user.role}`}
         color={division.color}
-        action={
-          division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-            <DivisionDropdown event={division.event} selected={division._id.toString()} />
-          )
-        }
+        user={user}
+        division={division}
       >
         <TabContext value={activeTab}>
           <Paper sx={{ mt: 4 }}>

--- a/apps/frontend/pages/lems/judge-advisor.tsx
+++ b/apps/frontend/pages/lems/judge-advisor.tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { WithId } from 'mongodb';
 import { enqueueSnackbar } from 'notistack';
-import { Avatar, Box, Paper, Tab, Tabs, Typography, Stack } from '@mui/material';
+import { Avatar, Box, Paper, Tab, Tabs, Typography } from '@mui/material';
 import { TabContext, TabPanel } from '@mui/lab';
 import Grid from '@mui/material/Grid2';
 import JudgingRoomIcon from '@mui/icons-material/Workspaces';
@@ -23,10 +23,7 @@ import {
 import { RoleAuthorizer } from '../../components/role-authorizer';
 import { getUserAndDivision, serverSideGetRequests } from '../../lib/utils/fetch';
 import RubricStatusReferences from '../../components/judging/rubric-status-references';
-import ConnectionIndicator from '../../components/connection-indicator';
 import Layout from '../../components/layout';
-import ReportLink from '../../components/general/report-link';
-import InsightsLink from '../../components/general/insights-link';
 import JudgingRoomSchedule from '../../components/judging/judging-room-schedule';
 import { localizedRoles } from '../../localization/roles';
 import { useWebsocket } from '../../hooks/use-websocket';
@@ -181,13 +178,10 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth={800}
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {divisionState.completed ? <InsightsLink /> : <ReportLink />}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
+        divisionState={divisionState}
         color={division.color}
       >
         <>

--- a/apps/frontend/pages/lems/judge.tsx
+++ b/apps/frontend/pages/lems/judge.tsx
@@ -17,7 +17,6 @@ import {
 import { RoleAuthorizer } from '../../components/role-authorizer';
 import RubricStatusReferences from '../../components/judging/rubric-status-references';
 import JudgingRoomSchedule from '../../components/judging/judging-room-schedule';
-import ConnectionIndicator from '../../components/connection-indicator';
 import Layout from '../../components/layout';
 import WelcomeHeader from '../../components/general/welcome-header';
 import JudgingTimer from '../../components/judging/judging-timer';
@@ -125,8 +124,7 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth={800}
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={<ConnectionIndicator status={connectionStatus} />}
+        connectionStatus={connectionStatus}
         color={division.color}
       >
         {currentSession && activeTeam ? (
@@ -200,6 +198,7 @@ const Page: NextPage<Props> = ({
 export const getServerSideProps: GetServerSideProps = async ctx => {
   try {
     const { user, divisionId } = await getUserAndDivision(ctx);
+    if (!user.roleAssociation) throw new Error('No role association found for judge.');
 
     const data = await serverSideGetRequests(
       {

--- a/apps/frontend/pages/lems/lead-judge.tsx
+++ b/apps/frontend/pages/lems/lead-judge.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { WithId } from 'mongodb';
-import { Avatar, Box, Paper, Typography, Stack } from '@mui/material';
+import { Avatar, Box, Paper, Typography } from '@mui/material';
 import JudgingRoomIcon from '@mui/icons-material/Workspaces';
 import {
   DivisionState,
@@ -18,10 +18,7 @@ import {
 import { RoleAuthorizer } from '../../components/role-authorizer';
 import RubricStatusReferences from '../../components/judging/rubric-status-references';
 import JudgingRoomSchedule from '../../components/judging/judging-room-schedule';
-import ConnectionIndicator from '../../components/connection-indicator';
 import Layout from '../../components/layout';
-import ReportLink from '../../components/general/report-link';
-import InsightsLink from '../../components/general/insights-link';
 import WelcomeHeader from '../../components/general/welcome-header';
 import { getUserAndDivision, serverSideGetRequests } from '../../lib/utils/fetch';
 import { localizedRoles } from '../../localization/roles';
@@ -136,13 +133,10 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth={800}
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {divisionState.completed ? <InsightsLink /> : <ReportLink />}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
+        divisionState={divisionState}
         color={division.color}
       >
         <>
@@ -201,7 +195,8 @@ const Page: NextPage<Props> = ({
 export const getServerSideProps: GetServerSideProps = async ctx => {
   try {
     const { user, divisionId } = await getUserAndDivision(ctx);
-    const category = user.roleAssociation.value;
+    const category = user.roleAssociation?.value;
+    if (!category) throw new Error('No category found for lead judge');
 
     const data = await serverSideGetRequests(
       {

--- a/apps/frontend/pages/lems/mc.tsx
+++ b/apps/frontend/pages/lems/mc.tsx
@@ -19,7 +19,6 @@ import { RoleAuthorizer } from '../../components/role-authorizer';
 import McSchedule from '../../components/mc/mc-schedule';
 import AwardsLineup from '../../components/mc/awards-lineup';
 import AwardsNotReadyCard from '../../components/mc/awards-not-ready-card';
-import ReportLink from '../../components/general/report-link';
 import { getUserAndDivision, serverSideGetRequests } from '../../lib/utils/fetch';
 import { localizedRoles } from '../../localization/roles';
 import { useWebsocket } from '../../hooks/use-websocket';
@@ -79,17 +78,22 @@ const Page: NextPage<Props> = ({
     if (newDivisionState) setDivisionState(newDivisionState);
   };
 
-  useWebsocket(division._id.toString(), ['field', 'pit-admin', 'audience-display'], undefined, [
-    { name: 'teamRegistered', handler: handleTeamRegistered },
-    { name: 'matchLoaded', handler: handleMatchEvent },
-    { name: 'matchStarted', handler: handleMatchEvent },
-    { name: 'matchAborted', handler: handleMatchEvent },
-    { name: 'matchCompleted', handler: handleMatchEvent },
-    { name: 'matchUpdated', handler: handleMatchEvent },
-    { name: 'audienceDisplayUpdated', handler: setDivisionState },
-    { name: 'presentationUpdated', handler: setDivisionState },
-    { name: 'awardsUpdated', handler: setAwards }
-  ]);
+  const { connectionStatus } = useWebsocket(
+    division._id.toString(),
+    ['field', 'pit-admin', 'audience-display'],
+    undefined,
+    [
+      { name: 'teamRegistered', handler: handleTeamRegistered },
+      { name: 'matchLoaded', handler: handleMatchEvent },
+      { name: 'matchStarted', handler: handleMatchEvent },
+      { name: 'matchAborted', handler: handleMatchEvent },
+      { name: 'matchCompleted', handler: handleMatchEvent },
+      { name: 'matchUpdated', handler: handleMatchEvent },
+      { name: 'audienceDisplayUpdated', handler: setDivisionState },
+      { name: 'presentationUpdated', handler: setDivisionState },
+      { name: 'awardsUpdated', handler: setAwards }
+    ]
+  );
 
   return (
     <RoleAuthorizer
@@ -103,7 +107,8 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth="lg"
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)}`}
-        action={<ReportLink />}
+        user={user}
+        connectionStatus={connectionStatus}
         color={division.color}
       >
         <TabContext value={activeTab}>

--- a/apps/frontend/pages/lems/pit-admin.tsx
+++ b/apps/frontend/pages/lems/pit-admin.tsx
@@ -3,12 +3,10 @@ import router from 'next/router';
 import { WithId } from 'mongodb';
 import { useState } from 'react';
 import { enqueueSnackbar } from 'notistack';
-import { Tabs, Tab, Paper, Stack } from '@mui/material';
+import { Tabs, Tab, Paper } from '@mui/material';
 import { TabContext, TabPanel } from '@mui/lab';
-import { DivisionWithEvent, Team, Ticket, SafeUser, EventUserAllowedRoles } from '@lems/types';
-import ConnectionIndicator from '../../components/connection-indicator';
+import { DivisionWithEvent, Team, Ticket, SafeUser } from '@lems/types';
 import Layout from '../../components/layout';
-import ReportLink from '../../components/general/report-link';
 import { RoleAuthorizer } from '../../components/role-authorizer';
 import TicketCreationPanel from '../../components/pit-admin/ticket-creation-panel';
 import TeamRegistrationPanel from '../../components/pit-admin/team-registration-panel';
@@ -18,7 +16,6 @@ import { useWebsocket } from '../../hooks/use-websocket';
 import TicketPanel from '../../components/general/ticket-panel';
 import { localizeDivisionTitle } from '../../localization/event';
 import { useQueryParam } from '../../hooks/use-query-param';
-import DivisionDropdown from '../../components/general/division-dropdown';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -89,16 +86,9 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth="md"
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-              <DivisionDropdown event={division.event} selected={division._id.toString()} />
-            )}
-            <ReportLink />
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         color={division.color}
       >
         <TabContext value={activeTab}>

--- a/apps/frontend/pages/lems/queuer.tsx
+++ b/apps/frontend/pages/lems/queuer.tsx
@@ -104,17 +104,22 @@ const Page: NextPage<Props> = ({
     if (newDivisionState) setDivisionState(newDivisionState);
   };
 
-  useWebsocket(division._id.toString(), ['field', 'pit-admin', 'judging'], undefined, [
-    { name: 'matchLoaded', handler: handleMatchEvent },
-    { name: 'matchStarted', handler: handleMatchEvent },
-    { name: 'matchCompleted', handler: handleMatchEvent },
-    { name: 'matchUpdated', handler: handleMatchEvent },
-    { name: 'teamRegistered', handler: handleTeamRegistered },
-    { name: 'judgingSessionStarted', handler: handleSessionEvent },
-    { name: 'judgingSessionCompleted', handler: handleSessionEvent },
-    { name: 'judgingSessionAborted', handler: handleSessionEvent },
-    { name: 'judgingSessionUpdated', handler: handleSessionEvent }
-  ]);
+  const { connectionStatus } = useWebsocket(
+    division._id.toString(),
+    ['field', 'pit-admin', 'judging'],
+    undefined,
+    [
+      { name: 'matchLoaded', handler: handleMatchEvent },
+      { name: 'matchStarted', handler: handleMatchEvent },
+      { name: 'matchCompleted', handler: handleMatchEvent },
+      { name: 'matchUpdated', handler: handleMatchEvent },
+      { name: 'teamRegistered', handler: handleTeamRegistered },
+      { name: 'judgingSessionStarted', handler: handleSessionEvent },
+      { name: 'judgingSessionCompleted', handler: handleSessionEvent },
+      { name: 'judgingSessionAborted', handler: handleSessionEvent },
+      { name: 'judgingSessionUpdated', handler: handleSessionEvent }
+    ]
+  );
 
   return (
     <RoleAuthorizer
@@ -129,6 +134,7 @@ const Page: NextPage<Props> = ({
         maxWidth="md"
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)} | מתחם ${localizedDivisionSection[user.roleAssociation?.value as string].name}`}
         color={division.color}
+        error={connectionStatus === 'disconnected'} // No room to actually show the indicator
       >
         <Box sx={{ overflowY: 'auto', pb: `${NAVIGATION_HEIGHT + NAVIGATION_PADDING}px` }}>
           {activeView === 0 && (

--- a/apps/frontend/pages/lems/referee.tsx
+++ b/apps/frontend/pages/lems/referee.tsx
@@ -11,7 +11,6 @@ import {
   Team
 } from '@lems/types';
 import { RoleAuthorizer } from '../../components/role-authorizer';
-import ConnectionIndicator from '../../components/connection-indicator';
 import Layout from '../../components/layout';
 import { getUserAndDivision, serverSideGetRequests } from '../../lib/utils/fetch';
 import { useWebsocket } from '../../hooks/use-websocket';
@@ -112,8 +111,7 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth={800}
         title={`שולחן ${table.name} | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={<ConnectionIndicator status={connectionStatus} />}
+        connectionStatus={connectionStatus}
         color={division.color}
       >
         <StrictRefereeDisplay
@@ -132,6 +130,7 @@ const Page: NextPage<Props> = ({
 export const getServerSideProps: GetServerSideProps = async ctx => {
   try {
     const { user, divisionId } = await getUserAndDivision(ctx);
+    if (!user.roleAssociation) throw new Error('No role association found for referee');
 
     const data = await serverSideGetRequests(
       {

--- a/apps/frontend/pages/lems/reports/award-schema.tsx
+++ b/apps/frontend/pages/lems/reports/award-schema.tsx
@@ -11,20 +11,12 @@ import {
   TableHead,
   TableRow
 } from '@mui/material';
-import {
-  DivisionWithEvent,
-  SafeUser,
-  RoleTypes,
-  EventUserAllowedRoles,
-  Award,
-  AwardNames
-} from '@lems/types';
+import { DivisionWithEvent, SafeUser, RoleTypes, Award, AwardNames } from '@lems/types';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
 import Layout from '../../../components/layout';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
 import { localizedRoles } from '../../../localization/roles';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 import { localizedAward } from '@lems/season';
 
 interface Props {
@@ -49,13 +41,9 @@ const Page: NextPage<Props> = ({ user, division, awards }) => {
         maxWidth="md"
         title={`ממשק ${user.role && localizedRoles[user.role].name} - סדר הפרסים | ${localizeDivisionTitle(division)}`}
         back={`/lems/reports`}
-        backDisabled={false}
         color={division.color}
-        action={
-          division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-            <DivisionDropdown event={division.event} selected={division._id.toString()} />
-          )
-        }
+        user={user}
+        division={division}
       >
         <TableContainer component={Paper} sx={{ my: 4 }}>
           <Table>

--- a/apps/frontend/pages/lems/reports/field-schedule.tsx
+++ b/apps/frontend/pages/lems/reports/field-schedule.tsx
@@ -3,18 +3,15 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { WithId } from 'mongodb';
 import Grid from '@mui/material/Grid2';
-import { Stack } from '@mui/material';
 import {
   DivisionWithEvent,
   Team,
   SafeUser,
   RoleTypes,
   RobotGameMatch,
-  RobotGameTable,
-  EventUserAllowedRoles
+  RobotGameTable
 } from '@lems/types';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
-import ConnectionIndicator from '../../../components/connection-indicator';
 import Layout from '../../../components/layout';
 import ReportRoundSchedule from '../../../components/field/report-round-schedule';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
@@ -22,7 +19,6 @@ import { localizedRoles } from '../../../localization/roles';
 import { useWebsocket } from '../../../hooks/use-websocket';
 import { enqueueSnackbar } from 'notistack';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -114,15 +110,9 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth={1800}
         title={`ממשק ${user.role && localizedRoles[user.role].name} - לו״ז זירה | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-              <DivisionDropdown event={division.event} selected={division._id.toString()} />
-            )}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         back={`/lems/reports`}
         backDisabled={connectionStatus === 'connecting'}
         color={division.color}

--- a/apps/frontend/pages/lems/reports/field-status.tsx
+++ b/apps/frontend/pages/lems/reports/field-status.tsx
@@ -13,11 +13,9 @@ import {
   RobotGameMatch,
   RoleTypes,
   JudgingSession,
-  RobotGameTable,
-  EventUserAllowedRoles
+  RobotGameTable
 } from '@lems/types';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
-import ConnectionIndicator from '../../../components/connection-indicator';
 import Countdown from '../../../components/general/countdown';
 import FieldQueueReport from '../../../components/queueing/field-queue-report';
 import ActiveMatch from '../../../components/field/scorekeeper/active-match';
@@ -27,7 +25,6 @@ import { localizedRoles } from '../../../localization/roles';
 import { useWebsocket } from '../../../hooks/use-websocket';
 import { useTime } from '../../../hooks/use-time';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 
 interface MatchStatusTimerProps {
   activeMatch: WithId<RobotGameMatch> | null;
@@ -215,15 +212,9 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth="lg"
         title={`ממשק ${user.role && localizedRoles[user.role].name} - מצב הזירה | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-              <DivisionDropdown event={division.event} selected={division._id.toString()} />
-            )}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         back={`/lems/reports`}
         backDisabled={connectionStatus === 'connecting'}
         color={division.color}

--- a/apps/frontend/pages/lems/reports/general-schedule.tsx
+++ b/apps/frontend/pages/lems/reports/general-schedule.tsx
@@ -11,20 +11,13 @@ import {
   TableHead,
   TableRow
 } from '@mui/material';
-import {
-  DivisionWithEvent,
-  SafeUser,
-  RoleTypes,
-  DivisionScheduleEntry,
-  EventUserAllowedRoles
-} from '@lems/types';
+import { DivisionWithEvent, SafeUser, RoleTypes, DivisionScheduleEntry } from '@lems/types';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
 import Layout from '../../../components/layout';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
 import { localizedRoles } from '../../../localization/roles';
 import { enqueueSnackbar } from 'notistack';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 
 interface DivisionScheduleRowProps {
   entry: DivisionScheduleEntry;
@@ -64,13 +57,9 @@ const Page: NextPage<Props> = ({ user, division }) => {
         maxWidth="md"
         title={`ממשק ${user.role && localizedRoles[user.role].name} - לו״ז כללי | ${localizeDivisionTitle(division)}`}
         back={`/lems/reports`}
-        backDisabled={false}
         color={division.color}
-        action={
-          division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-            <DivisionDropdown event={division.event} selected={division._id.toString()} />
-          )
-        }
+        user={user}
+        division={division}
       >
         <TableContainer component={Paper} sx={{ mt: 4 }}>
           <Table>

--- a/apps/frontend/pages/lems/reports/index.tsx
+++ b/apps/frontend/pages/lems/reports/index.tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { Button, Paper, Typography } from '@mui/material';
 import Grid from '@mui/material/Grid2';
-import { SafeUser, DivisionWithEvent, RoleTypes, EventUserAllowedRoles } from '@lems/types';
+import { SafeUser, DivisionWithEvent, RoleTypes } from '@lems/types';
 import Layout from '../../../components/layout';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
@@ -11,7 +11,6 @@ import { localizedRoles } from '../../../localization/roles';
 import { enqueueSnackbar } from 'notistack';
 import { WithId } from 'mongodb';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 
 interface GridPaperLinkProps {
   path: string;
@@ -65,11 +64,8 @@ const Page: NextPage<Props> = ({ user, division }) => {
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)}`}
         back={user.role !== 'reports' ? `/lems/${user.role}` : undefined}
         color={division.color}
-        action={
-          division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-            <DivisionDropdown event={division.event} selected={division._id.toString()} />
-          )
-        }
+        user={user}
+        division={division}
       >
         <Grid container spacing={3} columns={6} direction="row" my={4}>
           <GridPaperLink path="judging-status">

--- a/apps/frontend/pages/lems/reports/judging-schedule.tsx
+++ b/apps/frontend/pages/lems/reports/judging-schedule.tsx
@@ -3,25 +3,22 @@ import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { WithId } from 'mongodb';
 import { enqueueSnackbar } from 'notistack';
-import { Switch, FormControlLabel, Stack } from '@mui/material';
+import { Switch, FormControlLabel } from '@mui/material';
 import {
   DivisionWithEvent,
   Team,
   JudgingRoom,
   SafeUser,
   JudgingSession,
-  RoleTypes,
-  EventUserAllowedRoles
+  RoleTypes
 } from '@lems/types';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
-import ConnectionIndicator from '../../../components/connection-indicator';
 import Layout from '../../../components/layout';
 import ReportJudgingSchedule from '../../../components/judging/report-judging-schedule';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
 import { localizedRoles } from '../../../localization/roles';
 import { useWebsocket } from '../../../hooks/use-websocket';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -88,15 +85,9 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth="md"
         title={`ממשק ${user.role && localizedRoles[user.role].name} - לו״ז שיפוט | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-              <DivisionDropdown event={division.event} selected={division._id.toString()} />
-            )}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         back={`/lems/reports`}
         backDisabled={connectionStatus === 'connecting'}
         color={division.color}

--- a/apps/frontend/pages/lems/reports/judging-status.tsx
+++ b/apps/frontend/pages/lems/reports/judging-status.tsx
@@ -27,11 +27,9 @@ import {
   DivisionState,
   RoleTypes,
   JUDGING_SESSION_LENGTH,
-  RobotGameMatch,
-  EventUserAllowedRoles
+  RobotGameMatch
 } from '@lems/types';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
-import ConnectionIndicator from '../../../components/connection-indicator';
 import StatusIcon from '../../../components/general/status-icon';
 import Layout from '../../../components/layout';
 import StyledTeamTooltip from '../../../components/general/styled-team-tooltip';
@@ -40,7 +38,6 @@ import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fe
 import { localizedRoles } from '../../../localization/roles';
 import { useWebsocket } from '../../../hooks/use-websocket';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 
 interface JudgingStatusTableProps {
   currentSessions: Array<WithId<JudgingSession>>;
@@ -276,15 +273,9 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth="lg"
         title={`ממשק ${user.role && localizedRoles[user.role].name} - מצב השיפוט | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-              <DivisionDropdown event={division.event} selected={division._id.toString()} />
-            )}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         back={`/lems/reports`}
         backDisabled={connectionStatus === 'connecting'}
         color={division.color}

--- a/apps/frontend/pages/lems/reports/notepad.tsx
+++ b/apps/frontend/pages/lems/reports/notepad.tsx
@@ -18,13 +18,12 @@ import Grid from '@mui/material/Grid2';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import EditOffOutlinedIcon from '@mui/icons-material/EditOffOutlined';
-import { DivisionWithEvent, SafeUser, RoleTypes, EventUserAllowedRoles, Team } from '@lems/types';
+import { DivisionWithEvent, SafeUser, RoleTypes, Team } from '@lems/types';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
 import Layout from '../../../components/layout';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
 import { localizedRoles } from '../../../localization/roles';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 import FormikTextField from '../../../components/general/forms/formik-text-field';
 import { Note, useNotes } from '../../../hooks/use-notes';
 import FormikTeamField from '../../../components/general/forms/formik-team-field';
@@ -120,11 +119,8 @@ const Page: NextPage<Props> = ({ user, division, teams }) => {
       <Layout
         maxWidth="md"
         title={`ממשק ${user.role && localizedRoles[user.role].name} - פתקים | ${localizeDivisionTitle(division)}`}
-        action={
-          division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-            <DivisionDropdown event={division.event} selected={division._id.toString()} />
-          )
-        }
+        user={user}
+        division={division}
         back="/lems/reports"
         color={division.color}
       >

--- a/apps/frontend/pages/lems/reports/pit-map.tsx
+++ b/apps/frontend/pages/lems/reports/pit-map.tsx
@@ -6,13 +6,12 @@ import { WithId } from 'mongodb';
 import { enqueueSnackbar } from 'notistack';
 import { Paper, Stack, Typography } from '@mui/material';
 import { grey } from '@mui/material/colors';
-import { DivisionWithEvent, SafeUser, RoleTypes, EventUserAllowedRoles } from '@lems/types';
+import { DivisionWithEvent, SafeUser, RoleTypes } from '@lems/types';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
 import Layout from '../../../components/layout';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
 import { localizedRoles } from '../../../localization/roles';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -36,11 +35,8 @@ const Page: NextPage<Props> = ({ user, division, pitMapUrl }) => {
       <Layout
         maxWidth="xl"
         title={`ממשק ${user.role && localizedRoles[user.role].name} - מפת פיטים | ${localizeDivisionTitle(division)}`}
-        action={
-          division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-            <DivisionDropdown event={division.event} selected={division._id.toString()} />
-          )
-        }
+        user={user}
+        division={division}
         back={`/lems/reports`}
         color={division.color}
       >

--- a/apps/frontend/pages/lems/reports/scoreboard.tsx
+++ b/apps/frontend/pages/lems/reports/scoreboard.tsx
@@ -3,7 +3,7 @@ import { WithId } from 'mongodb';
 import { GetServerSideProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { enqueueSnackbar } from 'notistack';
-import { Paper, Stack } from '@mui/material';
+import { Paper } from '@mui/material';
 import { DataGrid, GridColDef, GridComparatorFn } from '@mui/x-data-grid';
 import {
   DivisionWithEvent,
@@ -11,10 +11,8 @@ import {
   RoleTypes,
   SafeUser,
   Scoresheet,
-  Team,
-  EventUserAllowedRoles
+  Team
 } from '@lems/types';
-import ConnectionIndicator from '../../../components/connection-indicator';
 import Layout from '../../../components/layout';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
 import { useWebsocket } from '../../../hooks/use-websocket';
@@ -24,7 +22,6 @@ import { localizedRoles } from '../../../localization/roles';
 import { localizeTeam } from '../../../localization/teams';
 import { compareScoreArrays } from '@lems/utils/arrays';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -151,15 +148,9 @@ const Page: NextPage<Props> = ({
       <Layout
         maxWidth="md"
         title={`ממשק ${user.role && localizedRoles[user.role].name} - טבלת ניקוד | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-              <DivisionDropdown event={division.event} selected={division._id.toString()} />
-            )}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         back={`/lems/reports`}
         backDisabled={connectionStatus === 'connecting'}
         color={division.color}

--- a/apps/frontend/pages/lems/reports/team-list.tsx
+++ b/apps/frontend/pages/lems/reports/team-list.tsx
@@ -12,29 +12,19 @@ import {
   TableSortLabel,
   TableRow,
   Box,
-  IconButton,
-  Stack
+  IconButton
 } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
 import ContactPageRoundedIcon from '@mui/icons-material/ContactPageRounded';
-import {
-  DivisionWithEvent,
-  Team,
-  SafeUser,
-  RoleTypes,
-  Role,
-  EventUserAllowedRoles
-} from '@lems/types';
+import { DivisionWithEvent, Team, SafeUser, RoleTypes, Role } from '@lems/types';
 import BooleanIcon from '../../../components/general/boolean-icon';
 import { RoleAuthorizer } from '../../../components/role-authorizer';
-import ConnectionIndicator from '../../../components/connection-indicator';
 import Layout from '../../../components/layout';
 import { getUserAndDivision, serverSideGetRequests } from '../../../lib/utils/fetch';
 import { localizedRoles } from '../../../localization/roles';
 import { useWebsocket } from '../../../hooks/use-websocket';
 import { enqueueSnackbar } from 'notistack';
 import { localizeDivisionTitle } from '../../../localization/event';
-import DivisionDropdown from '../../../components/general/division-dropdown';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -112,15 +102,9 @@ const Page: NextPage<Props> = ({ user, division, teams: initialTeams }) => {
       <Layout
         maxWidth="md"
         title={`ממשק ${user.role && localizedRoles[user.role].name} - רשימת קבוצות | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-              <DivisionDropdown event={division.event} selected={division._id.toString()} />
-            )}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         back={`/lems/reports`}
         backDisabled={connectionStatus === 'connecting'}
         color={division.color}

--- a/apps/frontend/pages/lems/scorekeeper.tsx
+++ b/apps/frontend/pages/lems/scorekeeper.tsx
@@ -13,9 +13,7 @@ import {
   DivisionWithEvent
 } from '@lems/types';
 import { RoleAuthorizer } from '../../components/role-authorizer';
-import ConnectionIndicator from '../../components/connection-indicator';
 import Layout from '../../components/layout';
-import ReportLink from '../../components/general/report-link';
 import { getUserAndDivision, serverSideGetRequests } from '../../lib/utils/fetch';
 import { useWebsocket } from '../../hooks/use-websocket';
 import { useTime } from '../../hooks/use-time';
@@ -131,13 +129,9 @@ const Page: NextPage<Props> = ({
     >
       <Layout
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            <ReportLink />
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
         color={division.color}
       >
         <TabContext value={activeTab}>

--- a/apps/frontend/pages/lems/team/[teamId]/rubric/[judgingCategory].tsx
+++ b/apps/frontend/pages/lems/team/[teamId]/rubric/[judgingCategory].tsx
@@ -21,7 +21,6 @@ import { rubricsSchemas } from '@lems/season';
 import Layout from '../../../../../components/layout';
 import RubricForm from '../../../../../components/judging/rubrics/rubric-form';
 import { RoleAuthorizer } from '../../../../../components/role-authorizer';
-import ConnectionIndicator from '../../../../../components/connection-indicator';
 import {
   apiFetch,
   getUserAndDivision,
@@ -127,7 +126,6 @@ const Page: NextPage<Props> = ({ user, division, room, team, session, rubric: in
             localizedJudgingCategory[judgingCategory as JudgingCategory].name
           } של קבוצה #${team.number}, ${team.name} | ${localizeDivisionTitle(division)}`}
           error={connectionStatus === 'disconnected'}
-          action={<ConnectionIndicator status={connectionStatus} />}
           back={`/lems/${user.role}#${team.number.toString()}`}
           backDisabled={connectionStatus === 'connecting'}
           color={division.color}

--- a/apps/frontend/pages/lems/team/[teamId]/scoresheet/[scoresheetId].tsx
+++ b/apps/frontend/pages/lems/team/[teamId]/scoresheet/[scoresheetId].tsx
@@ -30,7 +30,6 @@ import {
 } from '@lems/types';
 import Layout from '../../../../../components/layout';
 import { RoleAuthorizer } from '../../../../../components/role-authorizer';
-import ConnectionIndicator from '../../../../../components/connection-indicator';
 import {
   apiFetch,
   getUserAndDivision,
@@ -232,7 +231,6 @@ const Page: NextPage<Props> = ({
             team.name
           } | ${localizeDivisionTitle(division)}`}
           error={connectionStatus === 'disconnected'}
-          action={<ConnectionIndicator status={connectionStatus} />}
           back={`/lems/${user.role}`}
           backDisabled={connectionStatus === 'connecting'}
           color={division.color}

--- a/apps/frontend/pages/lems/tournament-manager.tsx
+++ b/apps/frontend/pages/lems/tournament-manager.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import { GetServerSideProps, NextPage } from 'next';
 import { WithId } from 'mongodb';
 import { TabContext, TabPanel } from '@mui/lab';
-import { Paper, Tabs, Tab, Stack } from '@mui/material';
+import { Paper, Tabs, Tab } from '@mui/material';
 import {
   CoreValuesForm,
   DivisionWithEvent,
@@ -15,18 +15,14 @@ import {
   Team,
   Ticket,
   RobotGameTable,
-  RobotGameMatch,
-  EventUserAllowedRoles
+  RobotGameMatch
 } from '@lems/types';
 import Layout from '../../components/layout';
-import ReportLink from '../../components/general/report-link';
-import InsightsLink from '../../components/general/insights-link';
 import { RoleAuthorizer } from '../../components/role-authorizer';
 import TicketPanel from '../../components/general/ticket-panel';
 import DivisionPanel from '../../components/tournament-manager/division-panel';
 import JudgingScheduleEditor from '../../components/tournament-manager/judging-schedule-editor';
 import FieldScheduleEditor from '../../components/tournament-manager/field-schedule-editor';
-import ConnectionIndicator from '../../components/connection-indicator';
 import CVPanel from '../../components/cv-form/cv-panel';
 import BadgeTab from '../../components/general/badge-tab';
 import { useWebsocket } from '../../hooks/use-websocket';
@@ -34,7 +30,6 @@ import { localizedRoles } from '../../localization/roles';
 import { getUserAndDivision, serverSideGetRequests } from '../../lib/utils/fetch';
 import { localizeDivisionTitle } from '../../localization/event';
 import { useQueryParam } from '../../hooks/use-query-param';
-import DivisionDropdown from '../../components/general/division-dropdown';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -210,16 +205,10 @@ const Page: NextPage<Props> = ({
     >
       <Layout
         title={`ממשק ${user.role && localizedRoles[user.role].name} | ${localizeDivisionTitle(division)}`}
-        error={connectionStatus === 'disconnected'}
-        action={
-          <Stack direction="row" spacing={2}>
-            <ConnectionIndicator status={connectionStatus} />
-            {division.event.eventUsers.includes(user.role as EventUserAllowedRoles) && (
-              <DivisionDropdown event={division.event} selected={division._id.toString()} />
-            )}
-            {divisionState.completed ? <InsightsLink /> : <ReportLink />}
-          </Stack>
-        }
+        connectionStatus={connectionStatus}
+        user={user}
+        division={division}
+        divisionState={divisionState}
         color={division.color}
       >
         <TabContext value={activeTab}>

--- a/libs/types/src/lib/roles.ts
+++ b/libs/types/src/lib/roles.ts
@@ -20,6 +20,26 @@ export type Role = (typeof RoleTypes)[number];
 export const EventUserAllowedRoleTypes = ['tournament-manager', 'pit-admin'] as const;
 export type EventUserAllowedRoles = (typeof EventUserAllowedRoleTypes)[number];
 
+export const ReportsAllowedRoleTypes = [
+  'head-queuer',
+  'head-referee',
+  'judge-advisor',
+  'lead-judge',
+  'tournament-manager',
+  'pit-admin',
+  'scorekeeper',
+  'mc'
+] as const;
+export type ReportsAllowedRoles = (typeof ReportsAllowedRoleTypes)[number];
+
+export const InsightsAllowedRoleTypes = [
+  'head-referee',
+  'judge-advisor',
+  'tournament-manger',
+  'lead-judge'
+] as const;
+export type InsightsAllowedRoles = (typeof InsightsAllowedRoleTypes)[number];
+
 export const RoleAssociationTypes = ['room', 'table', 'category', 'section'] as const;
 export type RoleAssociationType = (typeof RoleAssociationTypes)[number];
 


### PR DESCRIPTION
## Description

Fixed a bug where admin users division id could not be identified, which caused crashes on multiple pages, notably exports.

Also cleaned up a bunch of code and moved it to `layout.tsx`

Closes #805

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
