### PR TITLE
Fix m14 to show right amount of points in the scoresheet

### DIFF
--- a/libs/season/src/lib/data/scoresheet.ts
+++ b/libs/season/src/lib/data/scoresheet.ts
@@ -185,7 +185,7 @@ export const scoresheet: ScoresheetSchema = {
             points += 20;
             break;
           case 2:
-            points += 10;
+            points += 30;
             break;
           default:
             break;


### PR DESCRIPTION
## Description

fix m14 to show right amount of points in the scoresheet ( if chose 2 it didnt add 20+10 just 10)

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
