### PR TITLE
Redesigned rubric exports

### DIFF
--- a/apps/frontend/components/export/export-rubric-feedback.tsx
+++ b/apps/frontend/components/export/export-rubric-feedback.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { WithId } from 'mongodb';
+import { Box, Stack } from '@mui/material';
+import Grid from '@mui/material/Grid2';
+import { rubricsSchemas } from '@lems/season';
+import { Rubric, JudgingCategory, DivisionWithEvent, Team } from '@lems/types';
+import { RubricAwards } from './rubrics/rubric-awards';
+import { SessionFeedbackHeader } from './rubrics/feedback-page/session-feedback-header';
+import SessionFeedbackTable from './rubrics/feedback-page/session-feedback-table';
+
+interface ExportRubricFeedbackProps {
+  rubrics: Array<WithId<Rubric<JudgingCategory>>>;
+  division: WithId<DivisionWithEvent>;
+  team: WithId<Team>;
+}
+
+export const ExportRubricFeedback: React.FC<ExportRubricFeedbackProps> = ({
+  rubrics,
+  division,
+  team
+}) => {
+  const cvrubric = rubrics.find(r => r.category === 'core-values');
+  if (!cvrubric) return null;
+
+  return (
+    <Box sx={{ pageBreakInside: 'avoid', mt: 0 }}>
+      <Box component="section" sx={{ mt: 0, position: 'relative' }}>
+        <Stack>
+          <Grid container sx={{ mb: 0.5 }}>
+            <SessionFeedbackHeader rubric={cvrubric} division={division} team={team} />
+            <SessionFeedbackTable rubrics={rubrics} />
+            <RubricAwards rubric={cvrubric} schema={rubricsSchemas[cvrubric.category]} size={12} />
+          </Grid>
+        </Stack>
+      </Box>
+    </Box>
+  );
+};
+
+export default ExportRubricFeedback;

--- a/apps/frontend/components/export/export-rubric-feedback.tsx
+++ b/apps/frontend/components/export/export-rubric-feedback.tsx
@@ -29,7 +29,13 @@ export const ExportRubricFeedback: React.FC<ExportRubricFeedbackProps> = ({
           <Grid container sx={{ mb: 0.5 }}>
             <SessionFeedbackHeader rubric={cvrubric} division={division} team={team} />
             <SessionFeedbackTable rubrics={rubrics} />
-            <RubricAwards rubric={cvrubric} schema={rubricsSchemas[cvrubric.category]} size={12} />
+            <Box sx={{ width: '100%', '@media print': { marginTop: '1cm' } }}>
+              <RubricAwards
+                rubric={cvrubric}
+                schema={rubricsSchemas[cvrubric.category]}
+                size={12}
+              />
+            </Box>
           </Grid>
         </Stack>
       </Box>

--- a/apps/frontend/components/export/export-rubric.tsx
+++ b/apps/frontend/components/export/export-rubric.tsx
@@ -1,0 +1,50 @@
+import { WithId } from 'mongodb';
+import { DivisionWithEvent, JudgingCategory, Rubric, Team } from '@lems/types';
+import Grid from '@mui/material/Grid2';
+import { Box, Stack } from '@mui/material';
+import { rubricsSchemas } from '@lems/season';
+import { RubricHeader } from './rubrics/rubric-header';
+import { RubricAwards } from './rubrics/rubric-awards';
+import { RubricTable } from './rubrics/rubric-table';
+import { RubricFeedback } from './rubrics/rubric-feedback';
+
+interface ExportRubricProps {
+  division: WithId<DivisionWithEvent>;
+  team: WithId<Team>;
+  rubric: WithId<Rubric<JudgingCategory>>;
+  showFeedback?: boolean;
+}
+
+export const ExportRubric: React.FC<ExportRubricProps> = ({
+  division,
+  team,
+  rubric,
+  showFeedback = true
+}) => {
+  const schema = rubricsSchemas[rubric.category];
+
+  return (
+    <>
+      <Box sx={{ pageBreakInside: 'avoid', mt: 0 }}>
+        <Box component="section" sx={{ mt: 0, position: 'relative' }}>
+          <Stack>
+            <Grid container sx={{ mb: 0.5 }}>
+              <RubricHeader
+                rubric={rubric}
+                schema={schema}
+                division={division}
+                team={{ number: team.number.toString() }}
+              />
+              <RubricAwards size={8} rubric={rubric} schema={schema} />
+              <RubricTable rubric={rubric} />
+              {showFeedback && <RubricFeedback rubric={rubric} />}
+            </Grid>
+          </Stack>
+        </Box>
+      </Box>
+      <Box sx={{ '@media print': { pageBreakBefore: 'always' } }} />
+    </>
+  );
+};
+
+export default ExportRubric;

--- a/apps/frontend/components/export/export-rubric.tsx
+++ b/apps/frontend/components/export/export-rubric.tsx
@@ -6,7 +6,6 @@ import { rubricsSchemas } from '@lems/season';
 import { RubricHeader } from './rubrics/rubric-header';
 import { RubricAwards } from './rubrics/rubric-awards';
 import { RubricTable } from './rubrics/rubric-table';
-import { RubricFeedback } from './rubrics/rubric-feedback';
 
 interface ExportRubricProps {
   division: WithId<DivisionWithEvent>;
@@ -25,24 +24,37 @@ export const ExportRubric: React.FC<ExportRubricProps> = ({
 
   return (
     <>
-      <Box sx={{ pageBreakInside: 'avoid', mt: 0 }}>
-        <Box component="section" sx={{ mt: 0, position: 'relative' }}>
-          <Stack>
-            <Grid container sx={{ mb: 0.5 }}>
-              <RubricHeader
-                rubric={rubric}
-                schema={schema}
-                division={division}
-                team={{ number: team.number.toString() }}
-              />
-              <RubricAwards size={8} rubric={rubric} schema={schema} />
-              <RubricTable rubric={rubric} />
-              {showFeedback && <RubricFeedback rubric={rubric} />}
-            </Grid>
-          </Stack>
-        </Box>
+      <Box
+        component="section"
+        sx={{
+          pageBreakInside: 'avoid !important',
+          breakInside: 'avoid !important',
+          position: 'relative',
+          boxSizing: 'border-box',
+          '@media print': {
+            margin: '0',
+            padding: '0',
+            maxHeight: '100vh',
+            overflow: 'hidden'
+          }
+        }}
+      >
+        <Stack spacing={0} sx={{ height: '100%' }}>
+          <Grid container>
+            <RubricHeader
+              rubric={rubric}
+              schema={schema}
+              division={division}
+              team={{ number: team.number.toString() }}
+            />
+            <RubricAwards size={8} rubric={rubric} schema={schema} />
+          </Grid>
+          <Box sx={{ flex: 1, minHeight: 0 }}>
+            <RubricTable rubric={rubric} showFeedback={showFeedback} />
+          </Box>
+        </Stack>
       </Box>
-      <Box sx={{ '@media print': { pageBreakBefore: 'always' } }} />
+      <Box sx={{ '@media print': { pageBreakAfter: 'always' } }} />
     </>
   );
 };

--- a/apps/frontend/components/export/rubrics/feedback-page/session-feedback-header.tsx
+++ b/apps/frontend/components/export/rubrics/feedback-page/session-feedback-header.tsx
@@ -1,0 +1,36 @@
+import { WithId } from 'mongodb';
+import { DivisionWithEvent, JudgingCategory, Rubric, SEASON_NAME, Team } from '@lems/types';
+import Grid from '@mui/material/Grid2';
+import { Stack, Typography } from '@mui/material';
+import { localizeDivisionTitle } from '../../../../localization/event';
+
+interface RubricHeaderProps {
+  rubric: WithId<Rubric<JudgingCategory>>;
+  division: WithId<DivisionWithEvent>;
+  team: WithId<Team>;
+}
+
+export const SessionFeedbackHeader: React.FC<RubricHeaderProps> = ({ rubric, division, team }) => {
+  return (
+    <>
+      <Grid size={10}>
+        <Stack justifyContent="space-between" height="100%" spacing={0.5}>
+          <Typography fontSize="0.65rem" color="textSecondary">
+            הופק מתוך מערכת האירועים של <em>FIRST</em> ישראל ({rubric._id.toString()}) |{' '}
+            {localizeDivisionTitle(division)} | עונת <span dir="ltr">{SEASON_NAME}</span>
+          </Typography>
+          <Typography fontSize="1.5rem" fontWeight={700}>
+            פידבק ממפגש השיפוט של קבוצה #{team.number}
+          </Typography>
+        </Stack>
+      </Grid>
+      <Grid size={2}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt="לוגו של תוכניות FIRST LEGO League Challenge"
+          src="/assets/audience-display/sponsors/fllc-horizontal.svg"
+        />
+      </Grid>
+    </>
+  );
+};

--- a/apps/frontend/components/export/rubrics/feedback-page/session-feedback-table.tsx
+++ b/apps/frontend/components/export/rubrics/feedback-page/session-feedback-table.tsx
@@ -35,7 +35,6 @@ const feedbackSections = [
 ];
 
 export const SessionFeedbackTable: React.FC<ExportCRSummaryProps> = ({ rubrics }) => {
-  // Get feedback for each category
   const getFeedback = (category: JudgingCategory) => {
     const rubric = rubrics.find(r => r.category === category);
     return {
@@ -46,14 +45,17 @@ export const SessionFeedbackTable: React.FC<ExportCRSummaryProps> = ({ rubrics }
 
   return (
     <Box
-      dir="rtl"
       sx={{
         width: '100%',
         overflow: 'hidden',
         borderRadius: '8px',
-        border: '2px solid #000',
+        border: '0.5px solid #000',
         pageBreakInside: 'avoid',
         backgroundColor: 'white',
+        '@media print': {
+          borderRadius: '15px',
+          border: '0.5px, solid #000'
+        },
         mt: 4
       }}
     >
@@ -64,8 +66,11 @@ export const SessionFeedbackTable: React.FC<ExportCRSummaryProps> = ({ rubrics }
           width: '100%',
           backgroundColor: 'white',
           '& .MuiTableCell-root': {
-            border: '2px solid black',
-            p: 2
+            border: '0.3px solid #666',
+            p: 1,
+            '@media print': {
+              border: '0.1px solid grey'
+            }
           }
         }}
       >
@@ -78,12 +83,27 @@ export const SessionFeedbackTable: React.FC<ExportCRSummaryProps> = ({ rubrics }
               py: 1,
               '@media print': {
                 backgroundColor: '#f8f9fa',
+                py: 0,
+                height: '12px',
+                minHeight: '12px',
+                maxHeight: '12px',
+                lineHeight: '12px',
                 WebkitPrintColorAdjust: 'exact',
                 printColorAdjust: 'exact'
               }
             }}
           >
-            <Typography fontWeight={600}>חשבו על...</Typography>
+            <Typography
+              fontWeight={600}
+              sx={{
+                '@media print': {
+                  lineHeight: '12px',
+                  height: '12px'
+                }
+              }}
+            >
+              חשבו על...
+            </Typography>
           </TableCell>
           <TableCell
             align="center"
@@ -93,36 +113,87 @@ export const SessionFeedbackTable: React.FC<ExportCRSummaryProps> = ({ rubrics }
               py: 1,
               '@media print': {
                 backgroundColor: '#f8f9fa',
+                py: 0,
+                height: '12px',
+                minHeight: '12px',
+                maxHeight: '12px',
+                lineHeight: '12px',
                 WebkitPrintColorAdjust: 'exact',
                 printColorAdjust: 'exact'
               }
             }}
           >
-            <Typography fontWeight={600}>עבודה מצוינת...</Typography>
+            <Typography
+              fontWeight={600}
+              sx={{
+                '@media print': {
+                  lineHeight: '12px',
+                  height: '12px'
+                }
+              }}
+            >
+              עבודה מצוינת...
+            </Typography>
           </TableCell>
         </TableRow>
-        {feedbackSections.map((section) => {
+        {feedbackSections.map(section => {
           const feedback = getFeedback(section.category);
           return (
             <React.Fragment key={section.title}>
               <TableRow>
                 <TableCell
                   colSpan={2}
+                  align="left"
                   sx={{
                     backgroundColor: section.color,
-                    py: '0.75em',
+                    border: '1px solid #000',
+                    boxSizing: 'border-box',
+                    fontSize: '1.4em',
+                    py: '0.3em',
+                    px: '1em',
                     '@media print': {
-                      backgroundColor: `${section.color} !important`,
+                      border: '0.1px solid black',
+                      py: 0,
+                      height: '12px',
+                      minHeight: '12px',
+                      maxHeight: '12px',
+                      lineHeight: '12px',
+                      px: '0.25em',
                       WebkitPrintColorAdjust: 'exact',
                       printColorAdjust: 'exact'
                     }
                   }}
                 >
-                  <Typography>
-                    <Box component="span" sx={{ fontWeight: 700 }}>
+                  <Typography
+                    sx={{
+                      '@media print': {
+                        lineHeight: '12px',
+                        height: '12px'
+                      }
+                    }}
+                  >
+                    <Box
+                      component="span"
+                      sx={{
+                        fontWeight: 700,
+                        '@media print': {
+                          lineHeight: '12px',
+                          height: '12px'
+                        }
+                      }}
+                    >
                       {section.title}
                     </Box>
-                    <Box component="span" sx={{ fontSize: '0.9em' }}>
+                    <Box
+                      component="span"
+                      sx={{
+                        fontSize: '0.9em',
+                        '@media print': {
+                          lineHeight: '12px',
+                          height: '12px'
+                        }
+                      }}
+                    >
                       {' - '}
                       {section.question}
                     </Box>
@@ -130,15 +201,45 @@ export const SessionFeedbackTable: React.FC<ExportCRSummaryProps> = ({ rubrics }
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell>
-                  <Typography>
-                    {feedback.thinkAbout}
-                  </Typography>
+                <TableCell
+                  sx={{
+                    backgroundColor: '#fff',
+                    border: '1px solid #000',
+                    boxSizing: 'border-box',
+                    fontSize: '1.4em',
+                    py: '3em',
+                    px: '1em',
+                    '@media print': {
+                      border: '0.1px solid grey',
+                      py: 0,
+                      pt: '0.5em',
+                      px: '0.25em',
+                      height: '100px',
+                      verticalAlign: 'top'
+                    }
+                  }}
+                >
+                  <Typography>{feedback.thinkAbout}</Typography>
                 </TableCell>
-                <TableCell>
-                  <Typography>
-                    {feedback.greatJob}
-                  </Typography>
+                <TableCell
+                  sx={{
+                    backgroundColor: '#fff',
+                    border: '1px solid #000',
+                    boxSizing: 'border-box',
+                    fontSize: '1.4em',
+                    py: '3em',
+                    px: '1em',
+                    '@media print': {
+                      border: '0.1px solid grey',
+                      py: 0,
+                      pt: '0.5em',
+                      px: '0.25em',
+                      height: '100px',
+                      verticalAlign: 'top'
+                    }
+                  }}
+                >
+                  <Typography>{feedback.greatJob}</Typography>
                 </TableCell>
               </TableRow>
             </React.Fragment>

--- a/apps/frontend/components/export/rubrics/feedback-page/session-feedback-table.tsx
+++ b/apps/frontend/components/export/rubrics/feedback-page/session-feedback-table.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { Box, Table, TableCell, TableRow, Typography } from '@mui/material';
+import { WithId } from 'mongodb';
+import { JudgingCategory, Rubric } from '@lems/types';
+
+interface ExportCRSummaryProps {
+  rubrics: Array<WithId<Rubric<JudgingCategory>>>;
+}
+
+const colors = {
+  'core-values': '#EBB3AA',
+  'innovation-project': '#D3DAEC',
+  'robot-design': '#DDE8D9'
+};
+
+const feedbackSections = [
+  {
+    title: 'ערכי הליבה',
+    color: colors['core-values'],
+    category: 'core-values' as JudgingCategory,
+    question: 'כיצד הקבוצה הדגימה עבודת צוות, גילוי, הכלה, חדשנות, השפעה והנאה בעבודתה?'
+  },
+  {
+    title: 'פרויקט החדשנות',
+    color: colors['innovation-project'],
+    category: 'innovation-project' as JudgingCategory,
+    question: 'כיצד הקבוצה זיהתה בעיה הקשורה לנושא של עונה וניגשה לפתור אותה?'
+  },
+  {
+    title: 'תכנון הרובוט',
+    color: colors['robot-design'],
+    category: 'robot-design' as JudgingCategory,
+    question: 'מה היתה גישת הקבוצה לפתרון משימות הרובוט בצורה בנויה ותכנית?'
+  }
+];
+
+export const SessionFeedbackTable: React.FC<ExportCRSummaryProps> = ({ rubrics }) => {
+  // Get feedback for each category
+  const getFeedback = (category: JudgingCategory) => {
+    const rubric = rubrics.find(r => r.category === category);
+    return {
+      greatJob: rubric?.data?.feedback?.greatJob || '',
+      thinkAbout: rubric?.data?.feedback?.thinkAbout || ''
+    };
+  };
+
+  return (
+    <Box
+      dir="rtl"
+      sx={{
+        width: '100%',
+        overflow: 'hidden',
+        borderRadius: '8px',
+        border: '2px solid #000',
+        pageBreakInside: 'avoid',
+        backgroundColor: 'white',
+        mt: 4
+      }}
+    >
+      <Table
+        sx={{
+          tableLayout: 'fixed',
+          borderCollapse: 'collapse',
+          width: '100%',
+          backgroundColor: 'white',
+          '& .MuiTableCell-root': {
+            border: '2px solid black',
+            p: 2
+          }
+        }}
+      >
+        <TableRow>
+          <TableCell
+            align="center"
+            sx={{
+              width: '50%',
+              backgroundColor: '#f8f9fa',
+              py: 1,
+              '@media print': {
+                backgroundColor: '#f8f9fa',
+                WebkitPrintColorAdjust: 'exact',
+                printColorAdjust: 'exact'
+              }
+            }}
+          >
+            <Typography fontWeight={600}>חשבו על...</Typography>
+          </TableCell>
+          <TableCell
+            align="center"
+            sx={{
+              width: '50%',
+              backgroundColor: '#f8f9fa',
+              py: 1,
+              '@media print': {
+                backgroundColor: '#f8f9fa',
+                WebkitPrintColorAdjust: 'exact',
+                printColorAdjust: 'exact'
+              }
+            }}
+          >
+            <Typography fontWeight={600}>עבודה מצוינת...</Typography>
+          </TableCell>
+        </TableRow>
+        {feedbackSections.map((section) => {
+          const feedback = getFeedback(section.category);
+          return (
+            <React.Fragment key={section.title}>
+              <TableRow>
+                <TableCell
+                  colSpan={2}
+                  sx={{
+                    backgroundColor: section.color,
+                    py: '0.75em',
+                    '@media print': {
+                      backgroundColor: `${section.color} !important`,
+                      WebkitPrintColorAdjust: 'exact',
+                      printColorAdjust: 'exact'
+                    }
+                  }}
+                >
+                  <Typography>
+                    <Box component="span" sx={{ fontWeight: 700 }}>
+                      {section.title}
+                    </Box>
+                    <Box component="span" sx={{ fontSize: '0.9em' }}>
+                      {' - '}
+                      {section.question}
+                    </Box>
+                  </Typography>
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>
+                  <Typography>
+                    {feedback.thinkAbout}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography>
+                    {feedback.greatJob}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            </React.Fragment>
+          );
+        })}
+      </Table>
+    </Box>
+  );
+};
+
+export default SessionFeedbackTable;

--- a/apps/frontend/components/export/rubrics/rubric-awards.tsx
+++ b/apps/frontend/components/export/rubrics/rubric-awards.tsx
@@ -1,0 +1,66 @@
+import { ResponsiveStyleValue } from '@mui/system';
+import { JudgingCategory, Rubric } from '@lems/types';
+import Grid, { GridSize } from '@mui/material/Grid2';
+import {
+  Checkbox,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography
+} from '@mui/material';
+import { RubricsSchema } from '@lems/season';
+import UncheckedIcon from '@mui/icons-material/CircleOutlined';
+import CheckedIcon from '@mui/icons-material/TaskAltRounded';
+import Markdown from 'react-markdown';
+
+interface RubricAwardsProps {
+  size: ResponsiveStyleValue<GridSize>;
+  rubric: Rubric<JudgingCategory>;
+  schema: RubricsSchema;
+}
+
+export const RubricAwards: React.FC<RubricAwardsProps> = ({ size, rubric, schema }) => {
+  if (!schema.awards) return <></>;
+
+  return (
+    <Grid size={size}>
+      <Typography variant="body2" gutterBottom textAlign="left" ml={6}>
+        אם הקבוצה הצטיינה באחד התחומים הבאים, נא לסמן את המשבצת המתאימה:
+      </Typography>
+      {schema.awards.map(award => (
+        <ListItem key={award.id} disablePadding>
+          <ListItemButton
+            dense
+            sx={{ borderRadius: 2, px: 2 }}
+            disabled={!rubric.data?.awards?.[award.id]}
+          >
+            <ListItemIcon sx={{ minWidth: 36 }}>
+              <Checkbox
+                edge="start"
+                tabIndex={-1}
+                disableRipple
+                icon={
+                  <UncheckedIcon
+                    sx={{
+                      fontSize: '1.5em',
+                      color: 'rgba(0,0,0,0.24)'
+                    }}
+                  />
+                }
+                checkedIcon={<CheckedIcon sx={{ fontSize: '1.5em', color: '#0071e3' }} />}
+                checked={rubric.data?.awards?.[award.id]}
+              />
+            </ListItemIcon>
+            <ListItemText>
+              <b>{award.title} - </b>{' '}
+              <Markdown skipHtml components={{ p: 'span' }}>
+                {award.description}
+              </Markdown>
+            </ListItemText>
+          </ListItemButton>
+        </ListItem>
+      ))}
+    </Grid>
+  );
+};

--- a/apps/frontend/components/export/rubrics/rubric-awards.tsx
+++ b/apps/frontend/components/export/rubrics/rubric-awards.tsx
@@ -21,18 +21,29 @@ interface RubricAwardsProps {
 }
 
 export const RubricAwards: React.FC<RubricAwardsProps> = ({ size, rubric, schema }) => {
-  if (!schema.awards) return <></>;
+  const awards = schema.awards;
+  if (!awards) return <></>;
 
   return (
     <Grid size={size}>
       <Typography variant="body2" gutterBottom textAlign="left" ml={6}>
         אם הקבוצה הצטיינה באחד התחומים הבאים, נא לסמן את המשבצת המתאימה:
       </Typography>
-      {schema.awards.map(award => (
-        <ListItem key={award.id} disablePadding>
+      {awards.map((award, index) => (
+        <ListItem key={`award-${award.id}`} disablePadding>
           <ListItemButton
             dense
-            sx={{ borderRadius: 2, px: 2 }}
+            sx={{
+              borderRadius: 2,
+              px: 2,
+              '@media print': {
+                borderRadius: 0,
+                borderBottom:
+                  index < awards.length - 1 ? '0.5px solid rgba(0,0,0,0.2)' : 'none',
+                paddingBottom: 1,
+                paddingTop: 1
+              }
+            }}
             disabled={!rubric.data?.awards?.[award.id]}
           >
             <ListItemIcon sx={{ minWidth: 36 }}>

--- a/apps/frontend/components/export/rubrics/rubric-feedback.tsx
+++ b/apps/frontend/components/export/rubrics/rubric-feedback.tsx
@@ -1,7 +1,6 @@
 import { WithId } from 'mongodb';
 import { JudgingCategory, Rubric } from '@lems/types';
-import Grid from '@mui/material/Grid2';
-import { Box, Table, TableCell, TableRow, Typography } from '@mui/material';
+import { Box, TableCell, TableRow, Typography } from '@mui/material';
 import { localizedJudgingCategory } from '@lems/season';
 
 const colors = {
@@ -22,124 +21,104 @@ interface RubricFeedbackProps {
 
 export const RubricFeedback: React.FC<RubricFeedbackProps> = ({ rubric }) => {
   return (
-    <Grid size={12} sx={{ mt: -6 }}>
-      <Box
-        dir="rtl"
-        sx={{
-          width: '100%',
-          transform: 'scale(0.9)',
-          transformOrigin: 'top right',
-          mt: rubric.category === 'core-values' ? 3 : -12,
-          ml: -5
-        }}
-      >
-        <Box
-          dir="rtl"
+    <>
+      <TableRow>
+        <TableCell
+          colSpan={2}
+          align="center"
           sx={{
-            mt: 0,
-            width: '103%',
-            ml: -1,
-            overflow: 'hidden',
-            borderRadius: '8px',
+            bgcolor: '#fff',
             border: '2px solid #000',
-            pageBreakInside: 'avoid',
-            backgroundColor: 'white'
+            boxSizing: 'border-box',
+            fontSize: '1.4em',
+            py: '1.5em',
+            px: '1em',
+            top: theme => theme.mixins.toolbar.minHeight,
+            '@media print': {
+              py: '0.5em',
+              px: '0.25em',
+              WebkitPrintColorAdjust: 'exact',
+              printColorAdjust: 'exact'
+            }
           }}
         >
-          <Table
-            sx={{
-              tableLayout: 'fixed',
-              borderCollapse: 'collapse',
-              width: '100%',
-              backgroundColor: 'white'
-            }}
-          >
-            <TableRow>
-              <TableCell
-                align="center"
-                sx={{
-                  width: '50%',
-                  borderBottom: '2px solid #000',
-                  borderLeft: '2px solid #000',
-                  borderRight: '2px solid #000',
-                  backgroundColor: '#f8f9fa',
-                  py: 1
-                }}
-              >
-                <Typography fontWeight={600}>עבודה מצוינת...</Typography>
-              </TableCell>
-              <TableCell
-                align="center"
-                sx={{
-                  width: '50%',
-                  borderBottom: '2px solid #000',
-                  borderLeft: '2px solid #000',
-                  backgroundColor: '#f8f9fa',
-                  py: 1
-                }}
-              >
-                <Typography fontWeight={600}>חשבו על...</Typography>
-              </TableCell>
-            </TableRow>
+          <Typography py={0.75} fontWeight={600}>
+            עבודה מצוינת...
+          </Typography>
+        </TableCell>
+        <TableCell
+          colSpan={2}
+          align="center"
+          sx={{ border: '2px solid #000', backgroundColor: '#fff' }}
+        >
+          <Typography py={0.75} fontWeight={600}>
+            חשבו על...
+          </Typography>
+        </TableCell>
+      </TableRow>
 
-            <TableRow>
-              <TableCell
-                colSpan={2}
-                sx={{
-                  borderBottom: '2px solid #000',
-                  backgroundColor: colors[rubric.category],
-                  py: '0.75em',
-                  '@media print': {
-                    backgroundColor: colors[rubric.category],
-                    WebkitPrintColorAdjust: 'exact',
-                    printColorAdjust: 'exact'
-                  }
-                }}
-              >
-                <Typography>
-                  <Box component="span" sx={{ fontWeight: 700 }}>
-                    {localizedJudgingCategory[rubric.category].name}
-                  </Box>
-                  <Box component="span" sx={{ fontSize: '0.9em' }}>
-                    {' - '}
-                    {headerText[rubric.category]}
-                  </Box>
-                </Typography>
-              </TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell
-                sx={{
-                  borderLeft: '2px solid #000',
-                  borderRight: '2px solid #000',
-                  borderBottom: '2px solid #000',
-                  p: 2,
-                  verticalAlign: 'top',
-                  minHeight: '150px',
-                  textAlign: 'right'
-                }}
-              >
-                <Typography sx={{ textAlign: 'left' }}>
-                  {rubric.data?.feedback?.greatJob || ''}
-                </Typography>
-              </TableCell>
-              <TableCell
-                sx={{
-                  borderBottom: '2px solid #000',
-                  p: 2,
-                  verticalAlign: 'top',
-                  minHeight: '150px',
-                  textAlign: 'right'
-                }}
-              >
-                <Typography sx={{ textAlign: 'left' }}>
-                  {rubric.data?.feedback?.thinkAbout || ''}
-                </Typography>
-              </TableCell>
-            </TableRow>
-          </Table>
-        </Box>
-      </Box>
-    </Grid>
+      <TableRow>
+        <TableCell
+          colSpan={4}
+          sx={{
+            border: '2px solid #000',
+            backgroundColor: colors[rubric.category],
+            py: 1,
+            '@media print': {
+              WebkitPrintColorAdjust: 'exact',
+              printColorAdjust: 'exact'
+            }
+          }}
+        >
+          <Typography py={0.75}>
+            <Box component="span" sx={{ fontWeight: 700 }}>
+              {localizedJudgingCategory[rubric.category].name}
+            </Box>
+            <Box component="span" sx={{ fontSize: '0.9em' }}>
+              {' - '}
+              {headerText[rubric.category]}
+            </Box>
+          </Typography>
+        </TableCell>
+      </TableRow>
+      <TableRow
+        sx={{
+          '@media print': {
+            marginBottom: '2cm'
+          }
+        }}
+      >
+        <TableCell
+          colSpan={2}
+          sx={{
+            border: '2px solid #000',
+            backgroundColor: '#fff',
+            p: 2,
+            verticalAlign: 'top',
+            minHeight: '150px',
+            textAlign: 'right'
+          }}
+        >
+          <Typography py={0.5} sx={{ textAlign: 'left' }}>
+            {rubric.data?.feedback?.greatJob || ''}
+          </Typography>
+        </TableCell>
+        <TableCell
+          colSpan={2}
+          sx={{
+            border: '2px solid #000',
+            backgroundColor: '#fff',
+            p: 2,
+            verticalAlign: 'top',
+            minHeight: '150px',
+            textAlign: 'right'
+          }}
+        >
+          <Typography py={0.5} sx={{ textAlign: 'left' }}>
+            {rubric.data?.feedback?.thinkAbout || ''}
+          </Typography>
+        </TableCell>
+      </TableRow>
+    </>
   );
 };

--- a/apps/frontend/components/export/rubrics/rubric-feedback.tsx
+++ b/apps/frontend/components/export/rubrics/rubric-feedback.tsx
@@ -1,0 +1,145 @@
+import { WithId } from 'mongodb';
+import { JudgingCategory, Rubric } from '@lems/types';
+import Grid from '@mui/material/Grid2';
+import { Box, Table, TableCell, TableRow, Typography } from '@mui/material';
+import { localizedJudgingCategory } from '@lems/season';
+
+const colors = {
+  'core-values': '#EBB3AA',
+  'innovation-project': '#D3DAEC',
+  'robot-design': '#DDE8D9'
+};
+
+const headerText = {
+  'core-values': 'כיצד הקבוצה הדגימה עבודת צוות, גילוי, הכלה, חדשנות, השפעה והנאה בעבודתה?',
+  'innovation-project': ' כיצד הקבוצה יזהתה בעיה הקשורה לנושא של עונה ותגשה לפתור אותה?',
+  'robot-design': ' מה היתה גישת הקבוצה לפתרון משימות הרובוט בצורה בנויה ותכנית?'
+};
+
+interface RubricFeedbackProps {
+  rubric: WithId<Rubric<JudgingCategory>>;
+}
+
+export const RubricFeedback: React.FC<RubricFeedbackProps> = ({ rubric }) => {
+  return (
+    <Grid size={12} sx={{ mt: -6 }}>
+      <Box
+        dir="rtl"
+        sx={{
+          width: '100%',
+          transform: 'scale(0.9)',
+          transformOrigin: 'top right',
+          mt: rubric.category === 'core-values' ? 3 : -12,
+          ml: -5
+        }}
+      >
+        <Box
+          dir="rtl"
+          sx={{
+            mt: 0,
+            width: '103%',
+            ml: -1,
+            overflow: 'hidden',
+            borderRadius: '8px',
+            border: '2px solid #000',
+            pageBreakInside: 'avoid',
+            backgroundColor: 'white'
+          }}
+        >
+          <Table
+            sx={{
+              tableLayout: 'fixed',
+              borderCollapse: 'collapse',
+              width: '100%',
+              backgroundColor: 'white'
+            }}
+          >
+            <TableRow>
+              <TableCell
+                align="center"
+                sx={{
+                  width: '50%',
+                  borderBottom: '2px solid #000',
+                  borderLeft: '2px solid #000',
+                  borderRight: '2px solid #000',
+                  backgroundColor: '#f8f9fa',
+                  py: 1
+                }}
+              >
+                <Typography fontWeight={600}>עבודה מצוינת...</Typography>
+              </TableCell>
+              <TableCell
+                align="center"
+                sx={{
+                  width: '50%',
+                  borderBottom: '2px solid #000',
+                  borderLeft: '2px solid #000',
+                  backgroundColor: '#f8f9fa',
+                  py: 1
+                }}
+              >
+                <Typography fontWeight={600}>חשבו על...</Typography>
+              </TableCell>
+            </TableRow>
+
+            <TableRow>
+              <TableCell
+                colSpan={2}
+                sx={{
+                  borderBottom: '2px solid #000',
+                  backgroundColor: colors[rubric.category],
+                  py: '0.75em',
+                  '@media print': {
+                    backgroundColor: colors[rubric.category],
+                    WebkitPrintColorAdjust: 'exact',
+                    printColorAdjust: 'exact'
+                  }
+                }}
+              >
+                <Typography>
+                  <Box component="span" sx={{ fontWeight: 700 }}>
+                    {localizedJudgingCategory[rubric.category].name}
+                  </Box>
+                  <Box component="span" sx={{ fontSize: '0.9em' }}>
+                    {' - '}
+                    {headerText[rubric.category]}
+                  </Box>
+                </Typography>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell
+                sx={{
+                  borderLeft: '2px solid #000',
+                  borderRight: '2px solid #000',
+                  borderBottom: '2px solid #000',
+                  p: 2,
+                  verticalAlign: 'top',
+                  minHeight: '150px',
+                  textAlign: 'right'
+                }}
+              >
+                <Typography sx={{ textAlign: 'left' }}>
+                  {rubric.data?.feedback?.greatJob || ''}
+                </Typography>
+              </TableCell>
+              <TableCell
+                sx={{
+                  borderBottom: '2px solid #000',
+                  p: 2,
+                  verticalAlign: 'top',
+                  minHeight: '150px',
+                  textAlign: 'right'
+                }}
+              >
+                <Typography sx={{ textAlign: 'left' }}>
+                  {rubric.data?.feedback?.thinkAbout || ''}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          </Table>
+        </Box>
+      </Box>
+    </Grid>
+  );
+};

--- a/apps/frontend/components/export/rubrics/rubric-header.tsx
+++ b/apps/frontend/components/export/rubrics/rubric-header.tsx
@@ -1,0 +1,51 @@
+import { WithId } from 'mongodb';
+import { JudgingCategory, Rubric, SEASON_NAME, DivisionWithEvent } from '@lems/types';
+import Grid from '@mui/material/Grid2';
+import { Stack, Typography } from '@mui/material';
+import { localizedJudgingCategory } from '@lems/season';
+import { RubricsSchema } from '@lems/season';
+import Markdown from 'react-markdown';
+import { localizeDivisionTitle } from '../../../localization/event';
+
+interface RubricHeaderProps {
+  rubric: WithId<Rubric<JudgingCategory>>;
+  schema: RubricsSchema;
+  division: WithId<DivisionWithEvent>;
+  team: {
+    number: string;
+  };
+}
+
+export const RubricHeader: React.FC<RubricHeaderProps> = ({ rubric, schema, division, team }) => {
+  const hasAwards = Object.entries(rubric.data?.awards ?? {}).length > 0;
+  console.log(rubric.category, hasAwards);
+
+  return (
+    <>
+      <Grid size={10}>
+        <Stack justifyContent="space-between" height="100%" spacing={0.5}>
+          <Typography fontSize="0.65rem" color="textSecondary">
+            הופק מתוך מערכת האירועים של <em>FIRST</em> ישראל ({rubric._id.toString()}) |{' '}
+            {localizeDivisionTitle(division)} | עונת <span dir="ltr">{SEASON_NAME}</span>
+          </Typography>
+          <Typography fontSize="1.5rem" fontWeight={700}>
+            מחוון {localizedJudgingCategory[rubric.category].name} של קבוצה #{team.number}
+          </Typography>
+        </Stack>
+      </Grid>
+      <Grid size={2}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt="לוגו של תוכניות FIRST LEGO League Challenge"
+          src="/assets/audience-display/sponsors/fllc-horizontal.svg"
+        />
+      </Grid>
+
+      <Grid size={hasAwards ? 4 : 12}>
+        <Typography fontSize="0.875rem">
+          <Markdown>{schema.description}</Markdown>
+        </Typography>
+      </Grid>
+    </>
+  );
+};

--- a/apps/frontend/components/export/rubrics/rubric-table.tsx
+++ b/apps/frontend/components/export/rubrics/rubric-table.tsx
@@ -1,0 +1,198 @@
+import { JudgingCategory, Rubric } from '@lems/types';
+import Grid from '@mui/material/Grid2';
+import {
+  Box,
+  FormControlLabel,
+  Radio,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
+import { rubricsSchemas } from '@lems/season';
+import RubricRadioIcon from '../../judging/rubrics/rubric-radio-icon';
+import HeaderRow from '../../judging/rubrics/header-row';
+import TitleRow from '../../judging/rubrics/title-row';
+
+interface RubricTableProps {
+  rubric: Rubric<JudgingCategory>;
+}
+
+export const RubricTable: React.FC<RubricTableProps> = ({ rubric }) => {
+  return (
+    <Grid size={12}>
+      <Box dir="rtl" sx={{ width: '115%', mt: 1, mb: -2, mr: -3, ml: -7 }}>
+        <Table
+          sx={{
+            tableLayout: 'fixed',
+            borderCollapse: 'collapse',
+            width: '100%',
+            transform: 'scale(0.8)',
+            transformOrigin: 'top center',
+            position: 'relative',
+            '& .MuiTableCell-root': {
+              padding: '3px 6px',
+              fontSize: '0.85rem',
+              lineHeight: 1.2,
+              height: 'auto'
+            },
+            '& .MuiTableHead-root .MuiTableCell-root': {
+              padding: '1em',
+              fontSize: '1em'
+            },
+            '& .MuiTypography-root': {
+              fontSize: '0.85rem',
+              lineHeight: 1.2
+            },
+            '& .MuiTableHead-root .MuiTypography-root': {
+              fontSize: '1em'
+            },
+            '& .MuiTableRow-root': {
+              minHeight: 'unset',
+              height: 'auto'
+            }
+          }}
+        >
+          <TableHead sx={{ border: '2px solid #000', p: '0.5rem 0.25rem' }}>
+            <HeaderRow
+              columns={rubricsSchemas[rubric.category].columns}
+              category={rubric.category}
+              hideDescriptions={rubric.category !== 'core-values'}
+            />
+          </TableHead>
+          {rubricsSchemas[rubric.category].sections.map(section => (
+            <TableBody key={section.title}>
+              <TitleRow
+                title={section.title}
+                description={section.description}
+                category={rubric.category}
+              />
+              {section.fields.map(field => {
+                const labels = [field.label_1, field.label_2, field.label_3, field.label_4];
+                const rubricValues = rubric.data?.values;
+                const isCoreValuesField = field.isCoreValuesField ?? false;
+
+                return (
+                  <>
+                    <TableRow>
+                      {labels.map((label, index) => {
+                        const cellValue = index + 1;
+                        const isCellSelected = rubricValues?.[field.id]?.value === cellValue;
+                        const comment = rubricValues?.[field.id]?.notes;
+
+                        return (
+                          <TableCell
+                            key={label ? label + index : index}
+                            align={label ? 'left' : 'center'}
+                            sx={{
+                              border: '2px solid #000',
+                              fontSize: '0.7rem',
+                              p: '0 0.5em',
+                              backgroundColor: '#fff'
+                            }}
+                          >
+                            <Box
+                              sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 0.5,
+                                width: '100%',
+                                minHeight: '2.5rem'
+                              }}
+                            >
+                              <FormControlLabel
+                                value={cellValue}
+                                control={
+                                  <Radio
+                                    disableRipple
+                                    checked={isCellSelected}
+                                    icon={
+                                      <RubricRadioIcon
+                                        checked={false}
+                                        isCoreValuesField={isCoreValuesField}
+                                        sx={{
+                                          fontSize: '1.7em',
+                                          color: 'rgba(0,0,0,0.24)'
+                                        }}
+                                      />
+                                    }
+                                    checkedIcon={
+                                      <RubricRadioIcon
+                                        checked={true}
+                                        isCoreValuesField={isCoreValuesField}
+                                        sx={{
+                                          fontSize: '1.7em',
+                                          color: '#0071e3'
+                                        }}
+                                      />
+                                    }
+                                  />
+                                }
+                                label=""
+                                sx={{
+                                  m: 0,
+                                  '.MuiFormControlLabel-label': { display: 'none' }
+                                }}
+                              />
+                              {isCellSelected && comment && index === 3 && (
+                                <Typography
+                                  component="span"
+                                  fontSize="0.7rem"
+                                  textAlign="left"
+                                  sx={{
+                                    ml: -1,
+                                    color: 'text.secondary'
+                                  }}
+                                >
+                                  נימוק: {comment}
+                                </Typography>
+                              )}
+                              <Box sx={{ flex: 1 }}>{label}</Box>
+                            </Box>
+                          </TableCell>
+                        );
+                      })}
+                    </TableRow>
+                  </>
+                );
+              })}
+            </TableBody>
+          ))}
+          {rubric.data?.values && rubric.category !== 'core-values' && (
+            <Box
+              sx={{
+                mt: 2,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                fontSize: '2rem',
+                color: 'text.secondary',
+                whiteSpace: 'nowrap'
+              }}
+            >
+              <RubricRadioIcon
+                checked={false}
+                isCoreValuesField={true}
+                sx={{ fontSize: '1.2em', color: 'rgba(0,0,0,0.24)' }}
+              />
+              <Typography
+                variant="caption"
+                sx={{
+                  whiteSpace: 'nowrap',
+                  fontSize: '0.9rem',
+                  fontStyle: 'italic',
+                  color: 'black'
+                }}
+              >
+                קריטריונים עם תיבת סימון זו מחשבים פעמיים בעת קביעת המועמדות לפרסים - גם להערכת
+                הנושא הנ׳׳ל וגם להערכת ערכי הליבה
+              </Typography>
+            </Box>
+          )}
+        </Table>
+      </Box>
+    </Grid>
+  );
+};

--- a/apps/frontend/components/export/rubrics/rubric-table.tsx
+++ b/apps/frontend/components/export/rubrics/rubric-table.tsx
@@ -1,5 +1,4 @@
-import { JudgingCategory, Rubric } from '@lems/types';
-import Grid from '@mui/material/Grid2';
+import { WithId } from 'mongodb';
 import {
   Box,
   FormControlLabel,
@@ -11,27 +10,53 @@ import {
   TableRow,
   Typography
 } from '@mui/material';
+import { JudgingCategory, Rubric } from '@lems/types';
 import { rubricsSchemas } from '@lems/season';
 import RubricRadioIcon from '../../judging/rubrics/rubric-radio-icon';
 import HeaderRow from '../../judging/rubrics/header-row';
 import TitleRow from '../../judging/rubrics/title-row';
+import { RubricFeedback } from './rubric-feedback';
 
 interface RubricTableProps {
-  rubric: Rubric<JudgingCategory>;
+  rubric: WithId<Rubric<JudgingCategory>>;
+  showFeedback?: boolean;
 }
 
-export const RubricTable: React.FC<RubricTableProps> = ({ rubric }) => {
+export const RubricTable: React.FC<RubricTableProps> = ({ rubric, showFeedback = true }) => {
   return (
-    <Grid size={12}>
-      <Box dir="rtl" sx={{ width: '115%', mt: 1, mb: -2, mr: -3, ml: -7 }}>
+    <>
+      <Box
+        dir="rtl"
+        sx={{
+          width: '115%',
+          mt: 1,
+          mb: -5,
+          mr: -3,
+          ml: -7,
+          '@media print': {
+            height: 'fit-content',
+            overflow: 'hidden',
+            pageBreakInside: 'avoid !important',
+            breakInside: 'avoid !important'
+          }
+        }}
+      >
         <Table
           sx={{
             tableLayout: 'fixed',
             borderCollapse: 'collapse',
+            maxWidth: '100%',
             width: '100%',
-            transform: 'scale(0.8)',
-            transformOrigin: 'top center',
             position: 'relative',
+            border: '2px solid #000',
+            transform: 'scale(0.75)',
+            transformOrigin: 'top center',
+            '@media print': {
+              width: '100%',
+              tableLayout: 'fixed',
+              pageBreakInside: 'avoid !important',
+              breakInside: 'avoid !important'
+            },
             '& .MuiTableCell-root': {
               padding: '3px 6px',
               fontSize: '0.85rem',
@@ -55,7 +80,7 @@ export const RubricTable: React.FC<RubricTableProps> = ({ rubric }) => {
             }
           }}
         >
-          <TableHead sx={{ border: '2px solid #000', p: '0.5rem 0.25rem' }}>
+          <TableHead sx={{ p: '0.5rem 0.25rem' }}>
             <HeaderRow
               columns={rubricsSchemas[rubric.category].columns}
               category={rubric.category}
@@ -160,39 +185,45 @@ export const RubricTable: React.FC<RubricTableProps> = ({ rubric }) => {
               })}
             </TableBody>
           ))}
-          {rubric.data?.values && rubric.category !== 'core-values' && (
-            <Box
-              sx={{
-                mt: 2,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1,
-                fontSize: '2rem',
-                color: 'text.secondary',
-                whiteSpace: 'nowrap'
-              }}
-            >
-              <RubricRadioIcon
-                checked={false}
-                isCoreValuesField={true}
-                sx={{ fontSize: '1.2em', color: 'rgba(0,0,0,0.24)' }}
-              />
-              <Typography
-                variant="caption"
-                sx={{
-                  whiteSpace: 'nowrap',
-                  fontSize: '0.9rem',
-                  fontStyle: 'italic',
-                  color: 'black'
-                }}
-              >
-                קריטריונים עם תיבת סימון זו מחשבים פעמיים בעת קביעת המועמדות לפרסים - גם להערכת
-                הנושא הנ׳׳ל וגם להערכת ערכי הליבה
-              </Typography>
-            </Box>
-          )}
+          {showFeedback && <RubricFeedback rubric={rubric} />}
         </Table>
       </Box>
-    </Grid>
+      {rubric.data?.values &&
+        (rubric.category === 'innovation-project' || rubric.category === 'robot-design') && (
+          <Box
+            mt={-28}
+            ml={-6}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              fontSize: '1.5rem',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              '@media print': {
+                transform: 'scale(0.75)'
+              }
+            }}
+          >
+            <RubricRadioIcon
+              checked={false}
+              isCoreValuesField={true}
+              sx={{ fontSize: '1em', color: 'rgba(0,0,0,0.24)' }}
+            />
+            <Typography
+              variant="caption"
+              sx={{
+                whiteSpace: 'nowrap',
+                fontSize: '0.7rem',
+                fontStyle: 'italic',
+                color: 'black'
+              }}
+            >
+              קריטריונים עם תיבת סימון זו מחשבים פעמיים בעת קביעת המועמדות לפרסים - גם להערכת הנושא
+              הנ׳׳ל וגם להערכת ערכי הליבה
+            </Typography>
+          </Box>
+        )}
+    </>
   );
 };

--- a/apps/frontend/components/judging/rubrics/exceeded-notes-cell.tsx
+++ b/apps/frontend/components/judging/rubrics/exceeded-notes-cell.tsx
@@ -18,7 +18,12 @@ const ExceededNotesCell: React.FC<ExceededNotesCellProps> = ({ name, placeholder
           borderLeft: '1px solid rgba(0,0,0,0.2)',
           borderBottom: 'none',
           backgroundColor: '#f1f1f1',
-          py: 1
+          py: 1,
+          '@media print': {
+            backgroundColor: '#f1f1f1',
+            WebkitPrintColorAdjust: 'exact',
+            printColorAdjust: 'exact'
+          }
         }}
       >
         <Field name={`${name}.notes`}>

--- a/apps/frontend/components/judging/rubrics/header-row.tsx
+++ b/apps/frontend/components/judging/rubrics/header-row.tsx
@@ -36,17 +36,20 @@ const HeaderRow: React.FC<HeaderRowProps> = ({
             border: '1.5px solid #000',
             boxSizing: 'border-box',
             borderRadius: getBorderRadius(index, columns.length),
-            fontSize: '1em',
-            py: '0.875em',
-            px: '0.5em',
+            fontSize: '1.4em',
+            py: '1.5em',
+            px: '1em',
             top: theme => theme.mixins.toolbar.minHeight,
             '@media print': {
               py: '0.5em',
-              px: '0.25em'
+              px: '0.25em',
+              bgcolor: colors[type][index],
+              WebkitPrintColorAdjust: 'exact',
+              printColorAdjust: 'exact'
             }
           }}
         >
-          <Typography fontSize="1em" fontWeight={700}>
+          <Typography fontSize="1.4em" fontWeight={700}>
             {typeof column === 'object' ? column.title : column}
           </Typography>
 

--- a/apps/frontend/components/judging/rubrics/title-row.tsx
+++ b/apps/frontend/components/judging/rubrics/title-row.tsx
@@ -30,7 +30,10 @@ const TitleRow = ({ title, description, category: type }: Props) => {
           fontWeight: 500,
           '@media print': {
             py: 0,
-            px: '0.25em'
+            px: '0.25em',
+            bgcolor: colors[type],
+            WebkitPrintColorAdjust: 'exact',
+            printColorAdjust: 'exact'
           }
         }}
         colSpan={4}

--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/frontend/pages/lems/export/[teamId]/rubrics.tsx
+++ b/apps/frontend/pages/lems/export/[teamId]/rubrics.tsx
@@ -1,268 +1,11 @@
 import { GetServerSideProps, NextPage } from 'next';
 import { WithId } from 'mongodb';
-import {
-  DivisionWithEvent,
-  JudgingCategory,
-  Rubric,
-  SEASON_NAME,
-  SafeUser,
-  Team
-} from '@lems/types';
-import { serverSideGetRequests } from '../../../../lib/utils/fetch';
-import Grid from '@mui/material/Grid2';
-import {
-  Box,
-  Checkbox,
-  Divider,
-  FormControlLabel,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Radio,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  Typography
-} from '@mui/material';
-import { localizedJudgingCategory, rubricsSchemas } from '@lems/season';
-import UncheckedIcon from '@mui/icons-material/CircleOutlined';
-import CheckedIcon from '@mui/icons-material/TaskAltRounded';
-import Markdown from 'react-markdown';
-import HeaderRow from '../../../../components/judging/rubrics/header-row';
-import TitleRow from '../../../../components/judging/rubrics/title-row';
+import { Box } from '@mui/material';
+import { DivisionWithEvent, JudgingCategory, Rubric, SafeUser, Team } from '@lems/types';
+import { ExportRubric } from '../../../../components/export/export-rubric';
+import { ExportRubricFeedback } from '../../../../components/export/export-rubric-feedback';
 import { RoleAuthorizer } from '../../../../components/role-authorizer';
-import { localizeDivisionTitle } from '../../../../localization/event';
-import { getUserAndDivision } from '../../../../lib/utils/fetch';
-
-interface ExportRubricPageProps {
-  division: WithId<DivisionWithEvent>;
-  team: WithId<Team>;
-  rubric: WithId<Rubric<JudgingCategory>>;
-}
-
-const ExportRubricPage: React.FC<ExportRubricPageProps> = ({ division, team, rubric }) => {
-  const schema = rubricsSchemas[rubric.category];
-  const isCoreValues = rubric.category === 'core-values';
-
-  return (
-    <>
-      <Grid container>
-        <Grid size={10}>
-          <Stack justifyContent="space-between" height="100%">
-            <Typography fontSize="0.75rem" color="textSecondary">
-              הופק מתוך מערכת האירועים של <em>FIRST</em> ישראל ({rubric._id.toString()}) |{' '}
-              {localizeDivisionTitle(division)} | עונת <span dir="ltr">{SEASON_NAME}</span>
-            </Typography>
-            <Typography fontSize="1.75rem" fontWeight={700}>
-              מחוון {localizedJudgingCategory[rubric.category].name} של קבוצה #{team.number}
-            </Typography>
-          </Stack>
-        </Grid>
-        <Grid size={2}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt="לוגו של תוכניות FIRST LEGO League Challenge"
-            src="/assets/audience-display/sponsors/fllc-horizontal.svg"
-          />
-        </Grid>
-        <Grid size={isCoreValues ? 4 : 12}>
-          <Typography fontSize="0.875rem">
-            <Markdown>{schema.description}</Markdown>
-          </Typography>
-        </Grid>
-        {isCoreValues && schema.awards && (
-          <Grid size={8}>
-            <Typography variant="body2" gutterBottom textAlign="center">
-              אם הקבוצה הצטיינה באחד התחומים הבאים, נא לסמן את המשבצת המתאימה:
-            </Typography>
-            {schema.awards.map(award => (
-              <ListItem key={award.id} disablePadding>
-                <ListItemButton
-                  dense
-                  sx={{ borderRadius: 2, px: 2 }}
-                  disabled={!rubric.data?.awards?.[award.id]}
-                >
-                  <ListItemIcon sx={{ minWidth: 36 }}>
-                    <Checkbox
-                      edge="start"
-                      tabIndex={-1}
-                      disableRipple
-                      icon={
-                        <UncheckedIcon
-                          sx={{
-                            fontSize: '1.5em',
-                            color: 'rgba(0,0,0,0.24)'
-                          }}
-                        />
-                      }
-                      checkedIcon={<CheckedIcon sx={{ fontSize: '1.5em', color: '#0071e3' }} />}
-                      checked={rubric.data?.awards?.[award.id]}
-                    />
-                  </ListItemIcon>
-                  <ListItemText>
-                    <b>{award.title} - </b>{' '}
-                    <Markdown
-                      skipHtml
-                      components={{
-                        p: 'span'
-                      }}
-                    >
-                      {award.description}
-                    </Markdown>
-                  </ListItemText>
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </Grid>
-        )}
-        <Grid mb={2} size={12}>
-          <Table
-            sx={{
-              tableLayout: 'fixed',
-              borderCollapse: 'collapse',
-              width: '100%',
-              pageBreakInside: 'avoid'
-            }}
-          >
-            <TableHead sx={{ border: '2px solid #000', p: '0.5rem 0.25rem' }}>
-              <HeaderRow
-                columns={schema.columns}
-                category={schema.category}
-                hideDescriptions={schema.category !== 'core-values'}
-              />
-            </TableHead>
-            {schema.sections.map(section => (
-              <TableBody key={section.title}>
-                <TitleRow
-                  title={section.title}
-                  description={section.description}
-                  category={schema.category}
-                />
-                {section.fields.map(field => {
-                  const labels = [field.label_1, field.label_2, field.label_3, field.label_4];
-                  const rubricValues = rubric.data?.values;
-
-                  return (
-                    <>
-                      <TableRow>
-                        {labels.map((label, index) => {
-                          const cellValue = index + 1;
-
-                          const isCellSelected = rubricValues?.[field.id]?.value === cellValue;
-                          return (
-                            <TableCell
-                              key={label ? label + index : index}
-                              align={label ? 'left' : 'center'}
-                              sx={{
-                                border: '2px solid #000',
-                                fontSize: '0.75em',
-                                p: '0 0.5em',
-                                backgroundColor: '#fff'
-                              }}
-                            >
-                              <FormControlLabel
-                                value={cellValue}
-                                control={
-                                  <Radio
-                                    disableRipple
-                                    sx={{ pl: '0.1em' }}
-                                    icon={
-                                      <UncheckedIcon
-                                        sx={{
-                                          fontSize: '1.5em',
-                                          color: 'rgba(0,0,0,0.24)'
-                                        }}
-                                      />
-                                    }
-                                    checkedIcon={
-                                      <CheckedIcon sx={{ fontSize: '1.5em', color: '#0071e3' }} />
-                                    }
-                                    checked={isCellSelected}
-                                  />
-                                }
-                                disabled={!isCellSelected}
-                                label={
-                                  <Typography
-                                    fontSize="0.75em"
-                                    fontWeight={isCellSelected ? 700 : undefined}
-                                    color={!isCellSelected ? 'textSecondary' : ''}
-                                  >
-                                    <Markdown skipHtml>{label || ''}</Markdown>
-                                  </Typography>
-                                }
-                                sx={{ mx: 0 }}
-                              />
-                            </TableCell>
-                          );
-                        })}
-                      </TableRow>
-                      {rubricValues?.[field.id].value === 4 && (
-                        <TableRow>
-                          <TableCell
-                            colSpan={4}
-                            sx={{
-                              border: '2px solid #000',
-                              backgroundColor: '#f1f1f1',
-                              py: 0
-                            }}
-                          >
-                            <Box sx={{ display: 'flex', alignItems: 'center', py: '0.25em' }}>
-                              <Typography
-                                fontWeight={500}
-                                sx={{
-                                  mr: 0.75,
-                                  color: 'rgba(0,0,0,0.6)'
-                                }}
-                                fontSize="0.875rem"
-                              >
-                                נימוק:
-                              </Typography>
-                              <Typography fontSize="0.875rem">
-                                {rubricValues?.[field.id].notes}
-                              </Typography>
-                            </Box>
-                          </TableCell>
-                        </TableRow>
-                      )}
-                    </>
-                  );
-                })}
-              </TableBody>
-            ))}
-          </Table>
-        </Grid>
-        <Grid size={5.5}>
-          <Stack spacing={1} textAlign="center">
-            <Typography fontWeight={700}>{schema.feedback?.fields.greatJob}</Typography>
-            <Typography fontSize="0.875rem">{rubric.data?.feedback.greatJob}</Typography>
-          </Stack>
-        </Grid>
-        <Grid size={1}>
-          <Divider orientation="vertical" variant="middle" />
-        </Grid>
-        <Grid size={5.5}>
-          <Stack spacing={1} textAlign="center">
-            <Typography fontWeight={700}>{schema.feedback?.fields.thinkAbout}</Typography>
-            <Typography fontSize="0.875rem">{rubric.data?.feedback.thinkAbout}</Typography>
-          </Stack>
-        </Grid>
-      </Grid>
-      {!isCoreValues && (
-        <Box
-          sx={{
-            '@media print': {
-              pageBreakBefore: 'always'
-            }
-          }}
-        />
-      )}
-    </>
-  );
-};
+import { serverSideGetRequests, getUserAndDivision } from '../../../../lib/utils/fetch';
 
 interface Props {
   user: WithId<SafeUser>;
@@ -271,17 +14,25 @@ interface Props {
   rubrics: Array<WithId<Rubric<JudgingCategory>>>;
 }
 
-const Page: NextPage<Props> = ({ user, division, team, rubrics }) => {
+const ExportRubricsPage: NextPage<Props> = ({ user, division, team, rubrics }) => {
   return (
     <RoleAuthorizer user={user} allowedRoles={[]}>
-      {rubrics.map(rubric => (
-        <ExportRubricPage
-          key={rubric._id.toString()}
-          division={division}
-          team={team}
-          rubric={rubric}
-        />
-      ))}
+      <Box sx={{ '@media print': { pageBreakAfter: 'avoid', pageBreakInside: 'avoid' } }}>
+        {rubrics.map(rubric => {
+          // if (rubric.category === 'core-values') return;
+
+          return (
+            <ExportRubric
+              key={rubric._id.toString()}
+              division={division}
+              team={team}
+              rubric={rubric}
+              showFeedback={true}
+            />
+          );
+        })}
+      </Box>
+      <ExportRubricFeedback rubrics={rubrics} division={division} team={team} />
     </RoleAuthorizer>
   );
 };
@@ -305,4 +56,4 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
   }
 };
 
-export default Page;
+export default ExportRubricsPage;

--- a/apps/frontend/pages/lems/export/[teamId]/rubrics.tsx
+++ b/apps/frontend/pages/lems/export/[teamId]/rubrics.tsx
@@ -1,6 +1,5 @@
 import { GetServerSideProps, NextPage } from 'next';
 import { WithId } from 'mongodb';
-import { Box } from '@mui/material';
 import { DivisionWithEvent, JudgingCategory, Rubric, SafeUser, Team } from '@lems/types';
 import { ExportRubric } from '../../../../components/export/export-rubric';
 import { ExportRubricFeedback } from '../../../../components/export/export-rubric-feedback';
@@ -17,21 +16,19 @@ interface Props {
 const ExportRubricsPage: NextPage<Props> = ({ user, division, team, rubrics }) => {
   return (
     <RoleAuthorizer user={user} allowedRoles={[]}>
-      <Box sx={{ '@media print': { pageBreakAfter: 'avoid', pageBreakInside: 'avoid' } }}>
-        {rubrics.map(rubric => {
-          // if (rubric.category === 'core-values') return;
+      {rubrics.map(rubric => {
+        if (rubric.category === 'core-values') return;
 
-          return (
-            <ExportRubric
-              key={rubric._id.toString()}
-              division={division}
-              team={team}
-              rubric={rubric}
-              showFeedback={true}
-            />
-          );
-        })}
-      </Box>
+        return (
+          <ExportRubric
+            key={rubric._id.toString()}
+            division={division}
+            team={team}
+            rubric={rubric}
+            showFeedback={true}
+          />
+        );
+      })}
       <ExportRubricFeedback rubrics={rubrics} division={division} team={team} />
     </RoleAuthorizer>
   );


### PR DESCRIPTION
## Description

new rubrics export- include new cr page with feedback
Closes #748

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

<img width="471" alt="Screenshot 2024-12-20 at 12 07 41" src="https://github.com/user-attachments/assets/0479fb39-136c-4145-a8c5-65441587126d" />
<img width="471" alt="Screenshot 2024-12-20 at 12 07 48" src="https://github.com/user-attachments/assets/46ac29be-b0b9-41a6-9ea6-bd9bba278eaa" />
<img width="471" alt="Screenshot 2024-12-20 at 12 07 53" src="https://github.com/user-attachments/assets/04866329-c5e7-48b8-84ae-1d06e88476a2" />



## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
