### PR TITLE
Reconnect WS after connection is dropped

### DIFF
--- a/apps/backend/src/websocket/index.ts
+++ b/apps/backend/src/websocket/index.ts
@@ -49,6 +49,11 @@ const websocket = (
     callback({ ok: true });
   });
 
+  socket.on('pingRooms', callback => {
+    const relevantRooms = Array.from(socket.rooms).filter(room => room !== socket.id);
+    callback({ ok: true, rooms: relevantRooms });
+  });
+
   socket.on('startJudgingSession', (...args) => handleStartSession(namespace, ...args));
 
   socket.on('abortJudgingSession', (...args) => handleAbortSession(namespace, ...args));

--- a/apps/frontend/components/connection-indicator.tsx
+++ b/apps/frontend/components/connection-indicator.tsx
@@ -22,6 +22,12 @@ const config: {
     text: 'מתחבר...'
   },
   disconnected: {
+    rippleColor: '#f87171',
+    textColor: '#000000',
+    backgroundColor: '#f4f4f4',
+    text: 'מנותק'
+  },
+  error: {
     rippleColor: '#ffffff',
     textColor: '#ffffff',
     backgroundColor: '#dc2626',

--- a/apps/frontend/components/layout.tsx
+++ b/apps/frontend/components/layout.tsx
@@ -70,7 +70,7 @@ const Layout: React.FC<LayoutProps> = ({
   const router = useRouter();
   const [open, setOpen] = useState<boolean>(false);
 
-  const isError = error || connectionStatus === 'disconnected';
+  const isError = error || connectionStatus === 'error';
   const isEventUser =
     (division?.event && user?.isAdmin) ||
     division?.event?.eventUsers.includes(user?.role as EventUserAllowedRoles);

--- a/apps/frontend/hooks/use-websocket.ts
+++ b/apps/frontend/hooks/use-websocket.ts
@@ -38,7 +38,6 @@ export const useWebsocket = (
     }
 
     socket.disconnect();
-    socket.disconnect();
     retryRef.current += 1;
     const delay = calculateDelay();
 
@@ -103,12 +102,11 @@ export const useWebsocket = (
       setConnectionStatus('connected');
 
       socket.emit('joinRoom', rooms, response => {
-        if (response.ok) {
-          heartbeat();
-        } else {
+        if (!response.ok) {
           setConnectionStatus('disconnected');
           reconnect();
         }
+        heartbeat();
       });
     };
 
@@ -128,7 +126,7 @@ export const useWebsocket = (
     if (wsevents) {
       for (const event of wsevents) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error
         socket.on(event.name, event.handler);
       }
     }

--- a/apps/frontend/hooks/use-websocket.ts
+++ b/apps/frontend/hooks/use-websocket.ts
@@ -1,6 +1,12 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { WSEventListener, ConnectionStatus, WSRoomName } from '@lems/types';
 import { getSocket } from '../lib/utils/websocket';
+
+const MAX_RETRIES = 5;
+const BASE_DELAY = 1000;
+const HEARTBEAT_INTERVAL = 1000;
+const HEARTBEAT_TIMEOUT = 800;
+const MAX_HEARTBEAT_FAILURES = 3;
 
 export const useWebsocket = (
   divisionId: string,
@@ -9,10 +15,51 @@ export const useWebsocket = (
   wsevents?: Array<WSEventListener>
 ) => {
   const socket = getSocket(divisionId);
-
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(
     socket.connected ? 'connected' : 'disconnected'
   );
+  const [retryCount, setRetryCount] = useState(0);
+  const [heartbeatFailures, setHeartbeatFailures] = useState(0);
+
+  const refreshConnection = useCallback(() => {
+    setConnectionStatus('connecting');
+    socket.disconnect();
+    socket.connect();
+
+    return new Promise(resolve => {
+      socket.emit('joinRoom', rooms, response => {
+        if (response?.ok) {
+          setConnectionStatus('connected');
+          setRetryCount(0);
+          setHeartbeatFailures(0);
+          resolve(true);
+        } else {
+          setConnectionStatus('disconnected');
+          resolve(false);
+        }
+      });
+    });
+  }, [rooms, socket]);
+
+  const reconnect = useCallback(async () => {
+    if (retryCount >= MAX_RETRIES) {
+      setConnectionStatus('disconnected');
+      return;
+    }
+
+    const delay = Math.min(BASE_DELAY * Math.pow(2, retryCount), 10000);
+    await new Promise(resolve => setTimeout(resolve, delay));
+
+    const success = await refreshConnection();
+    if (!success) {
+      setRetryCount(prev => prev + 1);
+    }
+  }, [retryCount, refreshConnection]);
+
+  const compareArrays = (arr1: string[], arr2: string[]) => {
+    if (arr1.length !== arr2.length) return false;
+    return arr1.every(item => arr2.includes(item));
+  };
 
   useEffect(() => {
     socket.connect();
@@ -24,7 +71,10 @@ export const useWebsocket = (
       setConnectionStatus('connected');
 
       socket.emit('joinRoom', rooms, response => {
-        // { ok: true }
+        if (!response.ok) {
+          setConnectionStatus('disconnected');
+          reconnect();
+        }
       });
     };
 
@@ -34,6 +84,12 @@ export const useWebsocket = (
 
     socket.on('connect', onConnect);
     socket.on('disconnect', onDisconnect);
+
+    socket.on('connect_error', (error: any) => {
+      console.error('Connection error:', error);
+      setConnectionStatus('disconnected');
+      reconnect();
+    });
 
     // TODO: Fix typing so that we don't need to ignore typescript
     if (wsevents) {
@@ -46,53 +102,74 @@ export const useWebsocket = (
 
     return () => {
       socket.off('connect', onConnect);
+      socket.off('connect_error');
       socket.off('disconnect', onDisconnect);
 
       if (wsevents) {
         for (const event of wsevents) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          socket.on(event.name, event.handler);
+          // @ts-expect-error
+          socket.off(event.name, event.handler);
         }
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [socket]);
 
   useEffect(() => {
-    const refreshConnection = () => {
-      setConnectionStatus('connecting');
-      socket.disconnect();
-      socket.connect();
-      socket.emit('joinRoom', rooms, () => {
-        setConnectionStatus('connected');
-      });
-    };
+    let timeoutId: NodeJS.Timeout;
+    let isActive = true;
 
-    const compareArrays = (arr1: string[], arr2: string[]) => {
-      if (arr1.length !== arr2.length) return false;
-      return arr1.every(item => arr2.includes(item));
-    };
+    const heartbeat = () => {
+      let responded = false;
 
-    const intervalId = setInterval(() => {
-      let gotResponse = false;
+      if (!socket.connected) {
+        setConnectionStatus('disconnected');
+        reconnect();
+        return;
+      }
 
-      socket
-        .timeout(500)
-        .emit('pingRooms', (err: Error, res?: { rooms: string[]; ok: boolean; error?: string }) => {
-          gotResponse = true;
-          if (err || !res || !compareArrays(res.rooms, rooms)) {
-            refreshConnection();
+      socket.timeout(HEARTBEAT_TIMEOUT).emit('pingRooms', (err, res) => {
+        if (!isActive) return;
+
+        responded = true;
+        if (err || !res || !compareArrays(res.rooms, rooms)) {
+          setHeartbeatFailures(prev => prev + 1);
+          if (heartbeatFailures >= MAX_HEARTBEAT_FAILURES) {
+            setConnectionStatus('disconnected');
+            reconnect();
           }
-        });
+        } else {
+          setHeartbeatFailures(0);
+        }
+      });
 
-      setTimeout(() => {
-        if (!gotResponse) refreshConnection();
-      }, 800);
-    }, 1000);
+      timeoutId = setTimeout(() => {
+        if (!isActive) return;
+        if (!responded) {
+          setHeartbeatFailures(prev => prev + 1);
+          if (heartbeatFailures >= MAX_HEARTBEAT_FAILURES) {
+            setConnectionStatus('disconnected');
+            reconnect();
+          }
+        }
+      }, HEARTBEAT_TIMEOUT);
+    };
 
-    return () => clearInterval(intervalId);
-  }, [socket, rooms]);
+    const intervalId = setInterval(heartbeat, HEARTBEAT_INTERVAL);
+
+    return () => {
+      isActive = false;
+      clearInterval(intervalId);
+      clearTimeout(timeoutId);
+    };
+  }, [socket, rooms, reconnect, heartbeatFailures]);
+
+  useEffect(() => {
+    return () => {
+      socket.disconnect();
+    };
+  }, [socket]);
 
   return { socket, connectionStatus };
 };

--- a/libs/types/src/lib/constants.ts
+++ b/libs/types/src/lib/constants.ts
@@ -13,7 +13,7 @@ export const DivisionSwatches = [
 
 export type Status = 'not-started' | 'in-progress' | 'completed';
 
-export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
+export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected' | 'error';
 
 export type MissionClauseType = 'boolean' | 'enum' | 'number';
 

--- a/libs/types/src/lib/websocket.ts
+++ b/libs/types/src/lib/websocket.ts
@@ -186,6 +186,10 @@ export interface WSClientEmittedEvents {
     callback: (response: { ok: boolean; error?: string }) => void
   ) => void;
 
+  pingRooms: (
+    callback: (response: { rooms: Array<string>; ok: boolean; error?: string }) => void
+  ) => void;
+
   createTicket: (
     divisionId: string,
     teamId: string | null,
@@ -270,7 +274,7 @@ export interface WSClientEmittedEvents {
   ) => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
 export interface WSInterServerEvents {
   // ...
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where websockets sometimes didn't connect after suddenly disconnecting. Previously, the websocket server only showed disconnected after the server itself went down. Now, every 1 second the server is pinged by each client to ensure a stable connection.

Closes #744 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
