### PR TITLE
Remade the event manager in tournament manager

### DIFF
--- a/apps/backend/src/routers/api/divisions/index.ts
+++ b/apps/backend/src/routers/api/divisions/index.ts
@@ -99,7 +99,7 @@ router.use(
   cvFormsRouter
 );
 
-router.use('/:divisionId/export', roleValidator('judge-advisor'), exportRouter);
+router.use('/:divisionId/export', roleValidator('tournament-manager'), exportRouter);
 
 router.use(
   '/:divisionId/insights',

--- a/apps/frontend/components/judging/judge-advisor/awards-panel.tsx
+++ b/apps/frontend/components/judging/judge-advisor/awards-panel.tsx
@@ -37,7 +37,6 @@ const AwardsPanel: React.FC<AwardsPanelProps> = ({
         teams={teams}
         socket={socket}
       />
-      <ResultExportPaper division={division} />
     </>
   );
 };

--- a/apps/frontend/components/tournament-manager/division-panel.tsx
+++ b/apps/frontend/components/tournament-manager/division-panel.tsx
@@ -1,7 +1,12 @@
+import React from 'react';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { WithId } from 'mongodb';
 import { enqueueSnackbar } from 'notistack';
+import { Division, DivisionState, JudgingCategoryTypes } from '@lems/types';
+import { localizedJudgingCategory } from '@lems/season';
+import { apiFetch } from '../../lib/utils/fetch';
+import ExportAction from './export-action';
 import {
   Button,
   Paper,
@@ -9,14 +14,13 @@ import {
   DialogActions,
   DialogContent,
   DialogContentText,
-  DialogTitle
+  DialogTitle,
+  Typography
 } from '@mui/material';
-import Grid from '@mui/material/Grid2';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
-import DownloadIcon from '@mui/icons-material/Download';
 import PublishIcon from '@mui/icons-material/Publish';
-import { Division, DivisionState } from '@lems/types';
-import { apiFetch } from '../../lib/utils/fetch';
+import Grid from '@mui/material/Grid2';
+import { red } from '@mui/material/colors';
 
 interface DivisionPanelProps {
   division: WithId<Division>;
@@ -61,47 +65,32 @@ const DivisionPanel: React.FC<DivisionPanelProps> = ({
     });
   };
 
+  const handleDownloadResults = () => {
+    enqueueSnackbar('הורדת תוצאות האירוע תהיה זמינה בקרוב', { variant: 'info' });
+  };
+
   return (
     <>
-      <Grid container component={Paper} p={2} alignItems="center" spacing={4}>
-        <Grid
-          size={{
-            lg: 4,
-            md: 6,
-            xs: 12
-          }}
-        >
-          <Button
-            variant="contained"
-            startIcon={<DoneAllIcon />}
-            disabled={divisionState.completed}
-            onClick={e => {
-              e.preventDefault();
-              setEndDivisionDialogOpen(true);
-            }}
-            fullWidth
-          >
-            סיום האירוע
-          </Button>
-        </Grid>
-        <Grid
-          size={{
-            lg: 4,
-            md: 6,
-            xs: 12
-          }}
-        >
-          <Button variant="contained" startIcon={<DownloadIcon />} fullWidth disabled>
-            הורדת תוצאות האירוע
-          </Button>
-        </Grid>
-        <Grid
-          size={{
-            lg: 4,
-            md: 6,
-            xs: 12
-          }}
-        >
+      <Paper sx={{ borderRadius: 3, boxShadow: 2, p: 3, textAlign: 'center' }}>
+        <Typography variant="h1" pb={3}>
+          ניהול האירוע
+        </Typography>
+        <Grid container spacing={2}>
+          {JudgingCategoryTypes.map(category => (
+            <React.Fragment key={category}>
+              <Grid size={6}>
+                <ExportAction division={division} path={`/rubrics/${category}`} sx={{ m: 1 }}>
+                  ייצוא מחווני {localizedJudgingCategory[category].name}
+                </ExportAction>
+              </Grid>
+            </React.Fragment>
+          ))}
+
+          <Grid size={6}>
+            <ExportAction division={division} path="/scores" sx={{ m: 1 }}>
+              ייצוא תוצאות זירה
+            </ExportAction>
+          </Grid>
           <Button
             variant="contained"
             startIcon={<PublishIcon />}
@@ -114,8 +103,21 @@ const DivisionPanel: React.FC<DivisionPanelProps> = ({
           >
             פרסום התוצאות ב-Dashboard
           </Button>
+          <Button
+            variant="contained"
+            startIcon={<DoneAllIcon />}
+            disabled={divisionState.completed}
+            onClick={e => {
+              e.preventDefault();
+              setEndDivisionDialogOpen(true);
+            }}
+            fullWidth
+            sx={{ backgroundColor: red['A200'], color: 'white' }}
+          >
+            סיום האירוע
+          </Button>
         </Grid>
-      </Grid>
+      </Paper>
       <Dialog
         open={endDivisionDialogOpen}
         onClose={() => setEndDivisionDialogOpen(false)}

--- a/apps/frontend/components/tournament-manager/export-action.tsx
+++ b/apps/frontend/components/tournament-manager/export-action.tsx
@@ -2,7 +2,7 @@ import { WithId } from 'mongodb';
 import { Button, ButtonProps } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import { Division } from '@lems/types';
-import { getApiBase } from '../../../lib/utils/fetch';
+import { getApiBase } from '../../lib/utils/fetch';
 
 interface ExportActionProps extends ButtonProps {
   division: WithId<Division>;


### PR DESCRIPTION
## Description

moved the export grid from judge-advisor to tournament-manager + ui touches

Closes #768 


## Screenshots

![Screenshot 2024-12-31 001234](https://github.com/user-attachments/assets/c75a68df-dc01-4d43-a5d8-47a380fcfbb4)

👇


![Screenshot 2024-12-31 001846](https://github.com/user-attachments/assets/676b8e2e-7b5f-4bcd-bcbc-b54cb5852ec8)
