### PR TITLE
Fix snackbar not loading if the page is redirecting

### DIFF
--- a/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
+++ b/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
@@ -64,7 +64,7 @@ const Page: NextPage<Props> = ({ user, teams, division, cvForm: initialCvForm })
             socket={socket}
             cvForm={cvForm}
             readOnly={true}
-            onSubmit={() => setTimeout(() => router.push(`/lems/${user.role}`), 1000)}
+            onSubmit={() => setTimeout(() => router.push(`/lems/${user.role}`), 100)}
           />
         </Paper>
       </Layout>

--- a/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
+++ b/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
@@ -64,7 +64,7 @@ const Page: NextPage<Props> = ({ user, teams, division, cvForm: initialCvForm })
             socket={socket}
             cvForm={cvForm}
             readOnly={true}
-            onSubmit={() => router.push(`/lems/${user.role}`)}
+            onSubmit={() => setTimeout(() => router.push(`/lems/${user.role}`), 1000)}
           />
         </Paper>
       </Layout>


### PR DESCRIPTION
## Description

I noticed a small detail: when submitting the form, I was disconnected from the ws, which caused the "form updated" snackbar not be loaded. To fix this, I added a small delay (100 ms) before redirecting back to the user's role page.  

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
