### PR TITLE
Added CV Form to HeadRef and FTA

### DIFF
--- a/apps/backend/src/routers/api/divisions/index.ts
+++ b/apps/backend/src/routers/api/divisions/index.ts
@@ -95,7 +95,13 @@ router.use(
 
 router.use(
   '/:divisionId/cv-forms',
-  roleValidator(['judge-advisor', 'tournament-manager', 'lead-judge', 'head-referee']),
+  roleValidator([
+    'judge-advisor',
+    'tournament-manager',
+    'lead-judge',
+    'head-referee',
+    'field-manager'
+  ]),
   cvFormsRouter
 );
 

--- a/apps/backend/src/routers/api/divisions/index.ts
+++ b/apps/backend/src/routers/api/divisions/index.ts
@@ -95,7 +95,7 @@ router.use(
 
 router.use(
   '/:divisionId/cv-forms',
-  roleValidator(['judge-advisor', 'tournament-manager', 'lead-judge']),
+  roleValidator(['judge-advisor', 'tournament-manager', 'lead-judge', 'head-referee']),
   cvFormsRouter
 );
 

--- a/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
+++ b/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
@@ -40,7 +40,7 @@ const Page: NextPage<Props> = ({ user, teams, division, cvForm: initialCvForm })
   return (
     <RoleAuthorizer
       user={user}
-      allowedRoles={['judge-advisor', 'tournament-manager']}
+      allowedRoles={['judge-advisor', 'tournament-manager', 'head-referee']}
       onFail={() => {
         router.push(`/lems/${user.role}`);
         enqueueSnackbar('לא נמצאו הרשאות מתאימות.', { variant: 'error' });

--- a/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
+++ b/apps/frontend/pages/lems/cv-forms/[cvFormId].tsx
@@ -40,7 +40,7 @@ const Page: NextPage<Props> = ({ user, teams, division, cvForm: initialCvForm })
   return (
     <RoleAuthorizer
       user={user}
-      allowedRoles={['judge-advisor', 'tournament-manager', 'head-referee']}
+      allowedRoles={['judge-advisor', 'tournament-manager', 'head-referee', 'field-manager']}
       onFail={() => {
         router.push(`/lems/${user.role}`);
         enqueueSnackbar('לא נמצאו הרשאות מתאימות.', { variant: 'error' });


### PR DESCRIPTION
## Description

Hey,  
This PR adds tabs to headref and the FTA roles, including a new tab for managing CV Forms alongside the main functionality.  

Closes #925.  

### Type of Change

Please select the option(s) that best describe this change:

- [x] New feature (non-breaking change that adds functionality)  

### Questions for Further Implementation

1. I'm not sure if tab navigation is actually best approach here(made it for now because it was in all the other CV Form roles)
   Would it make more sense to move CV Forms to a small button (similar to the Reports button)? Which navigation approach would you prefer?

2. When creating a CV Form, the page does not reload, so the created form is not shown
   - Should this behavior be considered a bug and addressed in a separate issue?  
   - If we address it here, what approach would you prefer for fixing this? I thought maybe redirect back to the main role functionality page or reload the page with a timeout to show the new form

## Screenshots

![](https://github.com/user-attachments/assets/e7273aaf-a8a0-4f10-bf05-e9e4dd700b4d)  
![](https://github.com/user-attachments/assets/d5ef9f7a-f0bc-4cb0-a07b-82e335d9c426)  
