### PR TITLE
Fixed bug where copying schedule would use copied event start and end…

### DIFF
--- a/apps/frontend/components/admin/division-outline-editor.tsx
+++ b/apps/frontend/components/admin/division-outline-editor.tsx
@@ -61,14 +61,14 @@ const DivisionOutlineEditor: React.FC<DivisionOutlineEditorProps> = ({ event, di
 
   const copyScheduleFrom = (eventId: string | ObjectId, divisionId?: string | ObjectId) => {
     if (divisionId && String(divisionId) === String(division._id)) return;
-    const event = events.find(e => String(e._id) === String(eventId));
-    if (!event) return;
-    if (!divisionId && event?.enableDivisions) return;
+    const _event = events.find(e => String(e._id) === String(eventId));
+    if (!_event) return;
+    if (!divisionId && _event?.enableDivisions) return;
     let copyFromDivision;
     if (divisionId) {
-      copyFromDivision = event?.divisions?.find(d => String(d._id) === String(divisionId));
+      copyFromDivision = _event?.divisions?.find(d => String(d._id) === String(divisionId));
     } else {
-      copyFromDivision = event?.divisions?.[0];
+      copyFromDivision = _event?.divisions?.[0];
     }
     if (!copyFromDivision) return;
 


### PR DESCRIPTION
… date

## Description

This no longer happens:
![WhatsApp Image 2025-01-26 at 20 42 53_6392072e](https://github.com/user-attachments/assets/ef0bf739-f003-44c2-ad0a-067f0bfff078)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
