### PR TITLE
portal - implmented auto scroll at field schedule to current round

### DIFF
--- a/apps/portal/pages/events/[id]/schedule/field.tsx
+++ b/apps/portal/pages/events/[id]/schedule/field.tsx
@@ -20,6 +20,8 @@ import LoadingAnimation from '../../../../components/loading-animation';
 import { localizedMatchStage } from '../../../../lib/localization';
 import theme from '../../../../lib/theme';
 import StyledEventSubtitle from '../../../../components/events/styled-event-subtitle';
+import { useEffect } from 'react';
+import dayjs from 'dayjs';
 
 interface Props {
   event: PortalEvent;
@@ -32,6 +34,23 @@ const Page: NextPage<Props> = ({ event }) => {
     error
   } = useRealtimeData<PortalFieldSchedule>(`/events/${event.id}/schedule/field`);
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
+
+  const scrollToCurrentRound = (roundIndex: number) => {
+    const element = document.getElementById(`paper-${roundIndex}`);
+    element?.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+  };
+
+  useEffect(() => {
+    if (!schedule?.rounds) return;
+
+    const CurrentRound = schedule.rounds.findLastIndex(round =>
+      dayjs(
+        `${dayjs().format('YYYY-MM-DD')} ${Object.keys(round.schedule.rows).slice(-1)[0]}`
+      ).isBefore(dayjs())
+    );
+
+    scrollToCurrentRound(CurrentRound);
+  }, [schedule]);
 
   return (
     <Container maxWidth="md" sx={{ mt: 2 }}>
@@ -48,7 +67,7 @@ const Page: NextPage<Props> = ({ event }) => {
         {!isLoading && !error && (
           <Stack spacing={2} mt={2}>
             {schedule.rounds.map((round, index) => (
-              <Paper key={index} sx={{ p: 2 }}>
+              <Paper id={`paper-${index}`} key={index} sx={{ p: 2 }}>
                 <TableContainer>
                   <Table>
                     <TableHead>


### PR DESCRIPTION
## Description

portal field schedule now auto scroll on render to the current round

### Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots
![lems](https://github.com/user-attachments/assets/5f90b006-8a01-4e31-8556-5ef50ab21f32)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings


#### Idea
maybe also display at bold the current match? 