### PR TITLE
Portal - move team number to a separate line in team list

### DIFF
--- a/apps/portal/components/teams/team-list.tsx
+++ b/apps/portal/components/teams/team-list.tsx
@@ -49,7 +49,8 @@ const TeamList: React.FC<TeamListProps> = ({ eventId, teams }) => {
               onClick={() => router.push(`/events/${eventId}/teams/${team.number}`)}
             >
               <TableCell>
-                {team.name} #{team.number}
+                {team.name}
+                <br />#{team.number}
               </TableCell>
               <TableCell>
                 {team.affiliation.name}, {team.affiliation.city}


### PR DESCRIPTION
## Description

small fix that moves the team number under the name to keep it centered. It solves an issue where Hebrew and English names caused the number to shift left or right.

### Type of change

Please delete options that are not relevant.

- [x] UI idea

## Screenshots
#### before
![image](https://github.com/user-attachments/assets/ef5edf3d-7a95-4fa5-8d27-655b4b3ed529)
#### after
![image](https://github.com/user-attachments/assets/5cc9c6b2-ba53-4eea-997b-7b5ab829eb28)
