### PR TITLE
Portal - added to schedule tables sticky time coulums

### DIFF
--- a/apps/portal/pages/events/[id]/schedule/field.tsx
+++ b/apps/portal/pages/events/[id]/schedule/field.tsx
@@ -67,7 +67,13 @@ const Page: NextPage<Props> = ({ event }) => {
                         <TableCell>
                           <Typography fontWeight={500}>מקצה</Typography>
                         </TableCell>
-                        <TableCell>
+                        <TableCell
+                          sx={{
+                            position: 'sticky',
+                            left: 0,
+                            background: 'white'
+                          }}
+                        >
                           <Typography fontWeight={500}>זמן התחלה</Typography>
                         </TableCell>
                         {round.schedule.columns.map(column => (
@@ -84,7 +90,15 @@ const Page: NextPage<Props> = ({ event }) => {
                           sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
                         >
                           <TableCell>{teams.number}</TableCell>
-                          <TableCell>{dayjs.unix(Number(time)).format('HH:mm')}</TableCell>
+                          <TableCell
+                            sx={{
+                              position: 'sticky',
+                              left: 0,
+                              background: 'white'
+                            }}
+                          >
+                            {dayjs.unix(Number(time)).format('HH:mm')}
+                          </TableCell>
                           {round.schedule.columns.map(column => {
                             const team = teams.data.find(t => t?.column === column.id);
                             return (

--- a/apps/portal/pages/events/[id]/schedule/field.tsx
+++ b/apps/portal/pages/events/[id]/schedule/field.tsx
@@ -52,11 +52,17 @@ const Page: NextPage<Props> = ({ event }) => {
               <Paper key={index} sx={{ p: 2 }}>
                 <TableContainer>
                   <Table>
-                    <TableHead>
+                    <TableHead sx={{ position: 'sticky', top: 0, zIndex: 10, background: 'white' }}>
                       <TableRow>
                         <TableCell
-                          colSpan={round.schedule.columns.length + 2}
                           align={isDesktop ? 'center' : 'left'}
+                          sx={{
+                            position: 'sticky',
+                            left: 0,
+                            background: 'white',
+                            width: 'fit-content', // Makes the width fit the content
+                            whiteSpace: 'nowrap' // Prevents wrapping
+                          }}
                         >
                           <Typography fontWeight={500}>
                             סבב {localizedMatchStage[round.stage]} #{round.number}
@@ -64,14 +70,15 @@ const Page: NextPage<Props> = ({ event }) => {
                         </TableCell>
                       </TableRow>
                       <TableRow>
-                        <TableCell>
+                        <TableCell sx={{ textAlign: 'center' }}>
                           <Typography fontWeight={500}>מקצה</Typography>
                         </TableCell>
                         <TableCell
                           sx={{
                             position: 'sticky',
                             left: 0,
-                            background: 'white'
+                            background: 'white',
+                            boxShadow: '2px 0 5px -2px rgba(0,0,0,0.2)'
                           }}
                         >
                           <Typography fontWeight={500}>זמן התחלה</Typography>
@@ -83,18 +90,20 @@ const Page: NextPage<Props> = ({ event }) => {
                         ))}
                       </TableRow>
                     </TableHead>
+
                     <TableBody>
                       {Object.entries(round.schedule.rows).map(([time, teams]) => (
                         <TableRow
                           key={time}
                           sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
                         >
-                          <TableCell>{teams.number}</TableCell>
+                          <TableCell sx={{ textAlign: 'center' }}>{teams.number}</TableCell>
                           <TableCell
                             sx={{
                               position: 'sticky',
                               left: 0,
-                              background: 'white'
+                              background: 'white',
+                              boxShadow: '2px 0 5px -2px rgba(0,0,0,0.2)'
                             }}
                           >
                             {dayjs.unix(Number(time)).format('HH:mm')}

--- a/apps/portal/pages/events/[id]/schedule/judging.tsx
+++ b/apps/portal/pages/events/[id]/schedule/judging.tsx
@@ -60,7 +60,8 @@ const Page: NextPage<Props> = ({ event }) => {
                       sx={{
                         position: 'sticky',
                         left: 0,
-                        background: 'white'
+                        background: 'white',
+                        boxShadow: '2px 0 5px -2px rgba(0,0,0,0.2)'
                       }}
                     >
                       <Typography fontWeight={500}>זמן התחלה</Typography>
@@ -80,7 +81,8 @@ const Page: NextPage<Props> = ({ event }) => {
                         sx={{
                           position: 'sticky',
                           left: 0,
-                          background: 'white'
+                          background: 'white',
+                          boxShadow: '2px 0 5px -2px rgba(0,0,0,0.2)'
                         }}
                       >
                         {dayjs.unix(Number(time)).format('HH:mm')}

--- a/apps/portal/pages/events/[id]/schedule/judging.tsx
+++ b/apps/portal/pages/events/[id]/schedule/judging.tsx
@@ -47,10 +47,22 @@ const Page: NextPage<Props> = ({ event }) => {
               <Table>
                 <TableHead>
                   <TableRow>
-                    <TableCell>
+                    <TableCell
+                      sx={{
+                        position: 'sticky',
+                        left: 0,
+                        background: 'white'
+                      }}
+                    >
                       <Typography fontWeight={500}>סבב</Typography>
                     </TableCell>
-                    <TableCell>
+                    <TableCell
+                      sx={{
+                        position: 'sticky',
+                        left: 0,
+                        background: 'white'
+                      }}
+                    >
                       <Typography fontWeight={500}>זמן התחלה</Typography>
                     </TableCell>
                     {schedule.columns.map(column => (
@@ -64,7 +76,15 @@ const Page: NextPage<Props> = ({ event }) => {
                   {Object.entries(schedule.rows).map(([time, session]) => (
                     <TableRow key={time} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
                       <TableCell>{session.number}</TableCell>
-                      <TableCell>{dayjs.unix(Number(time)).format('HH:mm')}</TableCell>
+                      <TableCell
+                        sx={{
+                          position: 'sticky',
+                          left: 0,
+                          background: 'white'
+                        }}
+                      >
+                        {dayjs.unix(Number(time)).format('HH:mm')}
+                      </TableCell>
                       {schedule.columns.map(column => {
                         const team = session.data.find(t => t?.column === column.id);
                         return (


### PR DESCRIPTION
## Description

added to schedule tables sticky time coulums

( It might make sense visually to stick also the round column, but it could take up unnecessary space on small phone screens,
should we do it? )

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

####  before
![before](https://github.com/user-attachments/assets/a77b64d5-f4b4-40ed-9888-1b862b9376c4)

#### after
![after](https://github.com/user-attachments/assets/358adec1-893f-4ba3-9546-bf17f687c679)

