### PR TITLE
matching hight in tables boxes

### DIFF
--- a/apps/frontend/components/field/scorekeeper/active-match.tsx
+++ b/apps/frontend/components/field/scorekeeper/active-match.tsx
@@ -63,6 +63,7 @@ const ActiveMatch: React.FC<ActiveMatchProps> = ({
           columns={match?.participants.filter(p => p.teamId).length}
           columnSpacing={1.5}
           mt={2}
+          alignItems="stretch"
         >
           {match &&
             match.participants
@@ -83,17 +84,16 @@ const ActiveMatch: React.FC<ActiveMatchProps> = ({
                       backgroundColor: participant.ready ? green[100] : red[100],
                       border: `1px solid ${participant.ready ? green[300] : red[300]}`,
                       borderRadius: '0.5rem',
-                      height: '100%'
+                      display: 'flex',
+                      flexDirection: 'column'
                     }}
                   >
-                    <Grid container spacing={1} columns={2} px={2} py={1}>
-                      <Grid size={1}>
-                        <Typography fontWeight={500}>#{participant.team?.number}</Typography>
-                        <Typography fontSize="0.875rem" color="textSecondary">
-                          {participant.tableName}
-                        </Typography>
-                      </Grid>
-                      <Grid alignItems="center" display="flex" size={1}>
+                    <Box sx={{ p: 2, flex: 1 }}>
+                      <Typography fontWeight={500}>#{participant.team?.number}</Typography>
+                      <Typography fontSize="0.875rem" color="textSecondary">
+                        {participant.tableName}
+                      </Typography>
+                      <Box sx={{ mt: 1, display: 'flex', alignItems: 'center' }}>
                         {participant.present === 'present' ? (
                           <Tooltip title="הקבוצה על המגרש" arrow>
                             <DoneRoundedIcon />
@@ -115,8 +115,8 @@ const ActiveMatch: React.FC<ActiveMatchProps> = ({
                             <RemoveRoundedIcon />
                           </Tooltip>
                         )}
-                      </Grid>
-                    </Grid>
+                      </Box>
+                    </Box>
                   </Grid>
                 );
               })}


### PR DESCRIPTION
## Description

matching hight in tables boxes 
### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

<img width="519" alt="Screenshot 2025-02-06 at 14 26 58" src="https://github.com/user-attachments/assets/518d55d0-f970-4809-a2b4-3bdb171d8dad" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
