### PR TITLE
todo in portal

### DIFF
--- a/apps/portal/components/teams/team-list.tsx
+++ b/apps/portal/components/teams/team-list.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import {
   Table,
   Typography,
@@ -6,7 +5,8 @@ import {
   TableCell,
   TableBody,
   TableContainer,
-  TableHead
+  TableHead,
+  Link
 } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import { PortalTeam } from '@lems/types';
@@ -17,7 +17,7 @@ interface TeamListProps {
 }
 
 const TeamList: React.FC<TeamListProps> = ({ eventId, teams }) => {
-  const router = useRouter();
+  const sortedTeams = [...teams].sort((a, b) => a.number - b.number);
 
   return (
     <TableContainer>
@@ -34,11 +34,10 @@ const TeamList: React.FC<TeamListProps> = ({ eventId, teams }) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {teams.map(team => (
+          {sortedTeams.map(team => (
             <TableRow
               key={team.id}
               sx={{
-                cursor: 'pointer',
                 '&:hover': {
                   backgroundColor: 'rgba(0, 0, 0, 0.04)'
                 },
@@ -46,17 +45,42 @@ const TeamList: React.FC<TeamListProps> = ({ eventId, teams }) => {
                   backgroundColor: 'rgba(0, 0, 0, 0.08)'
                 }
               }}
-              onClick={() => router.push(`/events/${eventId}/teams/${team.number}`)}
             >
               <TableCell>
-                {team.name}
-                <br />#{team.number}
+                <Link
+                  href={`/events/${eventId}/teams/${team.number}`}
+                  sx={{
+                    textDecoration: 'none',
+                    color: 'inherit',
+                    display: 'block'
+                  }}
+                >
+                  {team.name} #{team.number}
+                </Link>
               </TableCell>
               <TableCell>
-                {team.affiliation.name}, {team.affiliation.city}
+                <Link
+                  href={`/events/${eventId}/teams/${team.number}`}
+                  sx={{
+                    textDecoration: 'none',
+                    color: 'inherit',
+                    display: 'block'
+                  }}
+                >
+                  {team.affiliation.name}, {team.affiliation.city}
+                </Link>
               </TableCell>
               <TableCell>
-                <ChevronLeftIcon />
+                <Link
+                  href={`/events/${eventId}/teams/${team.number}`}
+                  sx={{
+                    textDecoration: 'none',
+                    color: 'inherit',
+                    display: 'block'
+                  }}
+                >
+                  <ChevronLeftIcon />
+                </Link>
               </TableCell>
             </TableRow>
           ))}

--- a/apps/portal/pages/events/[id]/schedule/field.tsx
+++ b/apps/portal/pages/events/[id]/schedule/field.tsx
@@ -12,7 +12,8 @@ import {
   Container,
   Box,
   Stack,
-  useMediaQuery
+  useMediaQuery,
+  Link
 } from '@mui/material';
 import { PortalEvent, PortalFieldSchedule } from '@lems/types';
 import { fetchEvent } from '../../../../lib/api';
@@ -88,7 +89,16 @@ const Page: NextPage<Props> = ({ event }) => {
                           {round.schedule.columns.map(column => {
                             const team = teams.data.find(t => t?.column === column.id);
                             return (
-                              <TableCell key={column.id}>{team ? `#${team.number}` : ''}</TableCell>
+                              <TableCell key={column.id}>
+                                {team ? (
+                                  <Link 
+                                    href={`/events/${event.id}/teams/${team.number}`}
+                                    sx={{ color: 'inherit', textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
+                                  >
+                                    #{team.number}
+                                  </Link>
+                                ) : ''}
+                              </TableCell>
                             );
                           })}
                         </TableRow>

--- a/apps/portal/pages/events/[id]/schedule/judging.tsx
+++ b/apps/portal/pages/events/[id]/schedule/judging.tsx
@@ -10,7 +10,8 @@ import {
   TableBody,
   Paper,
   Container,
-  Box
+  Box,
+  Link
 } from '@mui/material';
 import { PortalEvent, PortalJudgingSchedule } from '@lems/types';
 import { fetchEvent } from '../../../../lib/api';
@@ -68,7 +69,22 @@ const Page: NextPage<Props> = ({ event }) => {
                       {schedule.columns.map(column => {
                         const team = session.data.find(t => t?.column === column.id);
                         return (
-                          <TableCell key={column.id}>{team ? `#${team.number}` : ''}</TableCell>
+                          <TableCell key={column.id}>
+                            {team ? (
+                              <Link
+                                href={`/events/${event.id}/teams/${team.number}`}
+                                sx={{
+                                  color: 'inherit',
+                                  textDecoration: 'none',
+                                  '&:hover': { textDecoration: 'underline' }
+                                }}
+                              >
+                                #{team.number}
+                              </Link>
+                            ) : (
+                              ''
+                            )}
+                          </TableCell>
                         );
                       })}
                     </TableRow>


### PR DESCRIPTION
## Description
קבוצות באירוע display by number and not in random order

in evert schedule if you press on any team׳s number it will navigate to team׳s page

Closes #1004 

### Type of change


- [x] New feature (non-breaking change which adds functionality)

## Screenshots

<img width="1036" alt="Screenshot 2025-02-06 at 15 58 13" src="https://github.com/user-attachments/assets/c985ec0e-eea9-4a99-a005-e521bc620535" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
