### PR TITLE
audience display teams color based on division color

### DIFF
--- a/apps/frontend/components/audience-display/match-preview.tsx
+++ b/apps/frontend/components/audience-display/match-preview.tsx
@@ -4,8 +4,8 @@ import { Division, RobotGameMatch } from '@lems/types';
 import { Box, Paper, Stack, Typography } from '@mui/material';
 import { localizedMatchStage } from '../../localization/field';
 import Grid from '@mui/material/Grid2';
-import { blue, red } from '@mui/material/colors';
 import Image from 'next/image';
+import { alpha, darken } from '@mui/material/styles';
 
 interface MatchPreviewProps {
   division: WithId<Division>;
@@ -70,9 +70,9 @@ const MatchPreview: React.FC<MatchPreviewProps> = ({ division, match }) => {
                 <Grid key={p.teamId?.toString()} size={1}>
                   <Stack
                     sx={{
-                      color: division.color === 'red' ? red[800] : blue[800],
-                      border: `1px solid ${division.color === 'red' ? red[300] : blue[300]}`,
-                      backgroundColor: division.color === 'red' ? red[100] : blue[100]
+                      color: division?.color ? darken(division.color, 0.2) : undefined,
+                      border: `1px solid ${division?.color ? alpha(division.color, 0.7) : undefined}`,
+                      backgroundColor: division?.color ? alpha(division.color, 0.1) : undefined
                     }}
                     borderRadius="0.5rem"
                     px={5}


### PR DESCRIPTION
## Description
audience display teams color based on division color

Closes #1002 

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
![WhatsApp Image 2025-02-08 at 20 40 18](https://github.com/user-attachments/assets/29054fb6-d604-4f70-9a32-f53129d0940f)
![WhatsApp Image 2025-02-08 at 20 41 01](https://github.com/user-attachments/assets/a9198192-8493-47ad-a096-d1723f5775a4)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
