### PR TITLE
Determine the use of TLS in scheduler by enviorment variable

### DIFF
--- a/apps/scheduler/Dockerfile
+++ b/apps/scheduler/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update
 WORKDIR /src
 
 ARG MONGO_CA_CERTIFICATE
+ENV PYTHON_ENV=production
 ENV MONGO_CA_CERTIFICATE=$MONGO_CA_CERTIFICATE
 RUN echo $MONGO_CA_CERTIFICATE > /root/mongo-ca-certificate.crt
 

--- a/apps/scheduler/src/repository/lems_repository.py
+++ b/apps/scheduler/src/repository/lems_repository.py
@@ -22,7 +22,7 @@ class LemsRepository:
         connection_string = os.getenv("MONGODB_URI", "mongodb://127.0.0.1:27017")
         self.divisionId = ObjectId(divisionId)
         self.client = MongoClient(
-            connection_string, tls=True, tlsAllowInvalidCertificates=True
+            connection_string, tls=os.getenv("PYTHON_ENV") == 'production', tlsAllowInvalidCertificates=True
         )
         self.db = self.client["lems"]
         logger.info(f"🔗 Connecting to MongoDB server at {connection_string}")


### PR DESCRIPTION
## Description
Enables TLS for MongoDB connections when PYTHON_ENV=production.
The Dockerfile sets this environment variable, the scheduler uses it to decide whether to connect to MongoDB with TLS as when running locally TLS doesn't needs to be used.  

Closes #1210 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
