### PR TITLE
Use foreign key for table instead of saving name in matches

### DIFF
--- a/apps/backend/src/lib/schedule/parser.ts
+++ b/apps/backend/src/lib/schedule/parser.ts
@@ -143,7 +143,6 @@ const extractMatchesFromMatchBlock = (
       match.participants.push({
         teamId: team?._id || null,
         tableId: table._id,
-        tableName: table.name,
         queued: false,
         ready: false,
         present: 'no-show'

--- a/apps/scheduler/src/repository/lems_repository.py
+++ b/apps/scheduler/src/repository/lems_repository.py
@@ -105,9 +105,6 @@ class LemsRepository:
             participants = []
             for table_id, _team_number in row[len(ignore_columns) :].items():
                 team_number = int(_team_number) if pd.notna(_team_number) else None
-                table_name = next(
-                    (table.name for table in tables if table.id == table_id), None
-                )
 
                 lems_team_id = self.get_lems_team_id(team_number)
                 if lems_team_id is not None:
@@ -115,7 +112,6 @@ class LemsRepository:
                         {
                             "teamId": lems_team_id,
                             "tableId": ObjectId(table_id),
-                            "tableName": table_name,
                             "queued": False,
                             "ready": False,
                             "present": "no-show",

--- a/libs/database/src/lib/crud/matches.ts
+++ b/libs/database/src/lib/crud/matches.ts
@@ -27,6 +27,21 @@ export const findMatches = (filter: Filter<RobotGameMatch>) => {
             }
           },
           {
+            $lookup: {
+              from: 'tables',
+              localField: 'participants.tableId',
+              foreignField: '_id',
+              as: 'participants.table'
+            }
+          },
+          {
+            $addFields: {
+              'participants.tableName': {
+                $arrayElemAt: ['$participants.table.name', 0]
+              }
+            }
+          },
+          {
             $group: {
               _id: '$_id',
               participants: { $push: '$participants' },


### PR DESCRIPTION
## Description

This PR removes the redundant `tableName` field from `matches.participants `during schedule parsing and generating. Instead, the table name is now dynamically populated using foreign key (`tabkeId`).

Closes #1201 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
