### PR TITLE
Added the ability to unregister teams from an event

### DIFF
--- a/apps/admin/locale/en.json
+++ b/apps/admin/locale/en.json
@@ -339,6 +339,14 @@
           },
           "no-teams-selected": "No teams selected"
         },
+        "unregister-dialog": {
+          "title": "Unregister Team",
+          "message": "Are you sure you want to unregister team #{number}? This action cannot be undone.",
+          "cancel": "Cancel",
+          "deleting": "Unregistering...",
+          "confirm": "Unregister Team",
+          "error": "Failed to unregister team."
+        },
         "unified": {
           "columns": {
             "division": "Division",

--- a/apps/admin/locale/he.json
+++ b/apps/admin/locale/he.json
@@ -346,6 +346,14 @@
           },
           "no-teams-selected": "לא נבחרו קבוצות"
         },
+        "unregister-dialog": {
+          "title": "ביטול רישום לקבוצה",
+          "message": "האם אתם בטוחים שברצונכם לבטל את הרישום של קבוצה #{number}? פעולה זו לא ניתנת לביטול",
+          "cancel": "ביטול",
+          "unregistering": "מבטל רישום...",
+          "confirm": "ביטול רישום",
+          "error": "ביטול רישום הקבוצה נכשל."
+        },
         "unified": {
           "columns": {
             "division": "בית",

--- a/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/components/event-teams-unified-view.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/components/event-teams-unified-view.tsx
@@ -3,18 +3,21 @@
 import { useMemo, useState } from 'react';
 import { DataGrid, GridColDef, GridActionsCellItem } from '@mui/x-data-grid';
 import { Avatar, Box, Chip } from '@mui/material';
-import { Edit, Delete } from '@mui/icons-material';
+import { Edit } from '@mui/icons-material';
 import { useTranslations } from 'next-intl';
-import { TeamWithDivision } from '@lems/types/api/admin';
+import { Event, TeamWithDivision } from '@lems/types/api/admin';
 import { UnifiedTeamsSearch } from './unified-teams-search';
+import { UnregisterTeamButton } from './unregister-team-button';
 
 interface EventTeamsUnifiedViewProps {
   teams: TeamWithDivision[];
+  event: Event;
   hasMultipleDivisions: boolean;
 }
 
 export const EventTeamsUnifiedView: React.FC<EventTeamsUnifiedViewProps> = ({
   teams,
+  event,
   hasMultipleDivisions
 }) => {
   const t = useTranslations('pages.events.teams.unified');
@@ -126,17 +129,7 @@ export const EventTeamsUnifiedView: React.FC<EventTeamsUnifiedViewProps> = ({
             console.log('Edit team:', params.row.id);
           }}
         />,
-        <GridActionsCellItem
-          key="delete"
-          icon={<Delete />}
-          label="Delete team"
-          // eslint-disable-next-line no-constant-binary-expression
-          disabled={true || params.row.division.hasSchedule}
-          onClick={() => {
-            // TODO: Implement delete functionality
-            console.log('Delete team:', params.row.id);
-          }}
-        />
+        <UnregisterTeamButton team={params.row} event={event} />
       ]
     }
   ];

--- a/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/components/unregister-team-button.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/components/unregister-team-button.tsx
@@ -1,0 +1,31 @@
+import { Delete } from '@mui/icons-material';
+import { GridActionsCellItem } from '@mui/x-data-grid';
+import { Event, TeamWithDivision } from '@lems/types/api/admin';
+import { useState } from 'react';
+import { UnregisterTeamDialog } from './unregister-team-dialog';
+
+interface UnregisterTeamButtonProps {
+  team: TeamWithDivision;
+  event: Event;
+}
+
+export const UnregisterTeamButton: React.FC<UnregisterTeamButtonProps> = ({ team, event }) => {
+  const [showUnregisterDialog, setShowUnregisterDialog] = useState(false);
+
+  return (
+    <>
+      <GridActionsCellItem
+        key="delete"
+        icon={<Delete />}
+        label="Delete team"
+        onClick={() => setShowUnregisterDialog(true)}
+      />
+      <UnregisterTeamDialog
+        team={team}
+        event={event}
+        open={showUnregisterDialog}
+        onClose={() => setShowUnregisterDialog(false)}
+      />
+    </>
+  );
+};

--- a/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/components/unregister-team-dialog.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/components/unregister-team-dialog.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { mutate } from 'swr';
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  CircularProgress,
+  Alert,
+  Collapse
+} from '@mui/material';
+import { Delete } from '@mui/icons-material';
+import { Event, TeamWithDivision } from '@lems/types/api/admin';
+import { apiFetch } from '@lems/shared';
+
+interface UnregisterTeamDialogProps {
+  team: TeamWithDivision;
+  event: Event;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const UnregisterTeamDialog: React.FC<UnregisterTeamDialogProps> = ({
+  team,
+  event,
+  open,
+  onClose
+}) => {
+  const t = useTranslations('pages.events.teams.unregister-dialog');
+
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDeleteSchedule = async () => {
+    setIsDeleting(true);
+    setError(null);
+    try {
+      const response = await apiFetch(`/admin/events/${event.id}/teams/unregister`, {
+        method: 'DELETE',
+        body: JSON.stringify([team.id]),
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      if (response.ok) {
+        await Promise.all([
+          mutate(`/admin/events/${event.id}/teams`),
+          mutate(`/admin/events/${event.id}/teams/available`)
+        ]);
+        onClose();
+      } else {
+        throw new Error(String(response.error));
+      }
+    } catch (err) {
+      setError(t('error'));
+      console.error('Error deleting team:', String(err));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+        <DialogTitle>{t('title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t('message', { number: team.number })}</DialogContentText>
+          <Collapse in={!!error}>
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {error}
+            </Alert>
+          </Collapse>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={isDeleting}>
+            {t('cancel')}
+          </Button>
+          <Button
+            onClick={handleDeleteSchedule}
+            color="error"
+            variant="contained"
+            disabled={isDeleting}
+            startIcon={isDeleting ? <CircularProgress size={18} /> : <Delete />}
+          >
+            {isDeleting ? t('deleting') : t('confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/page.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/page.tsx
@@ -52,7 +52,11 @@ export default function EventTeamsPage() {
 
         <Box sx={{ flex: 1, minHeight: 0 }}>
           {isUnified ? (
-            <EventTeamsUnifiedView teams={teams} hasMultipleDivisions={divisions.length > 1} />
+            <EventTeamsUnifiedView
+              teams={teams}
+              event={event}
+              hasMultipleDivisions={divisions.length > 1}
+            />
           ) : (
             <EventTeamsSplitView eventId={event.id} />
           )}

--- a/apps/backend/src/routers/admin/events/teams/index.ts
+++ b/apps/backend/src/routers/admin/events/teams/index.ts
@@ -34,4 +34,21 @@ router.post(
   }
 );
 
+router.delete(
+  '/unregister',
+  requirePermission('MANAGE_EVENT_DETAILS'),
+  async (req: AdminEventRequest, res) => {
+    const unregisterationData = req.body;
+
+    if (!unregisterationData || !Array.isArray(unregisterationData)) {
+      res.status(400).json({ error: 'Invalid teams unregistration data' });
+      return;
+    }
+
+    await db.events.byId(req.eventId).unregisterTeams(unregisterationData);
+
+    res.status(200).end();
+  }
+);
+
 export default router;

--- a/apps/backend/src/routers/admin/teams/index.ts
+++ b/apps/backend/src/routers/admin/teams/index.ts
@@ -28,7 +28,7 @@ router.get('/:number', async (req: AdminRequest, res) => {
   res.json(makeAdminTeamResponse(team));
 });
 
-router.delete('/:id', async (req: AdminRequest, res) => {
+router.delete('/:id', requirePermission('MANAGE_TEAMS'), async (req: AdminRequest, res) => {
   const id = req.params.id;
 
   const team = await db.teams.byId(id).get();

--- a/libs/database/src/repositories/events.ts
+++ b/libs/database/src/repositories/events.ts
@@ -193,6 +193,21 @@ class EventSelector {
     });
   }
 
+  /**
+   * Unregisters teams for a specific event.
+   * @param teams An array of team IDs to unregister.
+   * @returns
+   */
+  async unregisterTeams(teams: string[]): Promise<void> {
+    return this.db.transaction().execute(async trx => {
+      await Promise.all(
+        teams.map(team_id =>
+          trx.deleteFrom('team_divisions').where('team_id', '=', team_id).execute()
+        )
+      );
+    });
+  }
+
   async getSettings(): Promise<EventSettings | null> {
     const event = await this.get();
 


### PR DESCRIPTION
## Description

Teams can now be unregistered from the event->team page

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
