### PR TITLE
Color picker hex input and preset swatches

### DIFF
--- a/libs/shared/src/lib/components/color-picker.tsx
+++ b/libs/shared/src/lib/components/color-picker.tsx
@@ -24,6 +24,7 @@ interface ColorPickerProps {
 }
 
 const PRESET_COLORS = [
+  '#F12E6D',
   '#DF1125',
   '#FC4E12',
   '#E8C511',
@@ -31,7 +32,6 @@ const PRESET_COLORS = [
   '#1EA5FC',
   '#1E538F',
   '#5F41B2',
-  '#F12E6D',
   '#7A6E49',
   '#578887'
 ];


### PR DESCRIPTION
## Description

Add an hex input to the color picker and preset color swatches for consistency

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

<img width="612" height="452" alt="image" src="https://github.com/user-attachments/assets/80c9cdfd-d866-4743-a395-bffd9727c5b9" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
