### PR TITLE
Disable download password sheet when no users exist

### DIFF
--- a/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/users/components/volunteer-roles/volunteer-context.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/users/components/volunteer-roles/volunteer-context.tsx
@@ -181,6 +181,7 @@ export const VolunteerProvider: React.FC<VolunteerProviderProps> = ({ children }
 
       if (result.ok) {
         await mutate(`/admin/events/season/${event.seasonId}/summary`);
+        setIsLoadedFromDatabase(true);
         console.log('Volunteer slots saved successfully');
       } else {
         console.error('Failed to save volunteer slots:', result.status, result.error);

--- a/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/users/components/volunteer-roles/volunteer-users-section.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/users/components/volunteer-roles/volunteer-users-section.tsx
@@ -81,6 +81,7 @@ export function VolunteerUsersSection() {
             startIcon={<DownloadIcon />}
             onClick={handleDownloadPasswords}
             size="large"
+            disabled={isNew || saving}
             sx={{ flexShrink: 0 }}
           >
             {t('download-passwords')}


### PR DESCRIPTION
## Description

added `disabled={isNew || saving}` and made sure the isNew value is updating correspondingly.

I think it would improve UX to disable the btn when there are unsaved changes as well. Should I implement it?

Closes #1393

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![ezgif-26d4f6e4173057d2](https://github.com/user-attachments/assets/1aa6e916-f48d-425e-b813-5cf9582fa419)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
