### PR TITLE
Login button fix

### DIFF
--- a/apps/admin/src/app/[locale]/login/login-form.tsx
+++ b/apps/admin/src/app/[locale]/login/login-form.tsx
@@ -54,7 +54,7 @@ export function LoginForm({ recaptchaRequired }: LoginFormProps) {
   useRecaptcha(recaptchaRequired);
 
   const [showPassword, setShowPassword] = useState<boolean>(false);
-  const [disableAfterSuccess, setDisableAfterSuccess] = useState(false);
+  const [disableLogin, setDisableLogin] = useState(false);
 
   const initialValues: LoginFormValues = {
     username: '',
@@ -87,7 +87,7 @@ export function LoginForm({ recaptchaRequired }: LoginFormProps) {
       }
 
       removeRecaptchaBadge();
-      setDisableAfterSuccess(true); // keep login button disabled after success
+      setDisableLogin(true); // keep login button disabled after success
 
       const urlParams = new URLSearchParams(window.location.search);
       let returnUrl = urlParams.get('returnUrl') || '/';
@@ -164,7 +164,7 @@ export function LoginForm({ recaptchaRequired }: LoginFormProps) {
                     type="submit"
                     variant="contained"
                     size="large"
-                    disabled={disableAfterSuccess || isSubmitting || !isValid}
+                    disabled={disableLogin || isSubmitting || !isValid}
                     endIcon={<DirectionalIcon ltr={ChevronRight} rtl={ChevronLeft} />}
                     sx={{ borderRadius: 2, py: 1.5, width: '50%' }}
                   >

--- a/apps/frontend/src/app/[locale]/[event]/login/components/login-form.tsx
+++ b/apps/frontend/src/app/[locale]/[event]/login/components/login-form.tsx
@@ -39,7 +39,7 @@ export function LoginForm({ recaptchaRequired }: LoginFormProps) {
   const { getRole } = useRoleTranslations();
   const { needsDivision, needsRoleInfo, needsUser, volunteerData } = useVolunteer();
 
-  const [disableAfterSuccess, setDisableAfterSuccess] = useState(false);
+  const [disableLogin, setDisableLogin] = useState(false);
 
   function renderStep(currentStep: LoginStep) {
     switch (currentStep) {
@@ -52,7 +52,7 @@ export function LoginForm({ recaptchaRequired }: LoginFormProps) {
       case LoginStep.User:
         return <UserStep />;
       case LoginStep.Password:
-        return <PasswordStep disableAfterSuccess={disableAfterSuccess} />;
+        return <PasswordStep disableLogin={disableLogin} />;
       default:
         return null;
     }
@@ -69,7 +69,7 @@ export function LoginForm({ recaptchaRequired }: LoginFormProps) {
       await submitLogin(values, volunteerData, captchaToken);
 
       removeRecaptchaBadge();
-      setDisableAfterSuccess(true); // keep login button disabled after success
+      setDisableLogin(true); // keep login button disabled after success
 
       router.push(`/lems/${values.role}`);
     } catch (error) {

--- a/apps/frontend/src/app/[locale]/[event]/login/components/steps/password-step.tsx
+++ b/apps/frontend/src/app/[locale]/[event]/login/components/steps/password-step.tsx
@@ -6,7 +6,7 @@ import { useFormikContext } from 'formik';
 import { FormikTextField } from '@lems/shared';
 import { LoginFormValues } from '../../types';
 
-export function PasswordStep({disableAfterSuccess}: {disableAfterSuccess: boolean}) {
+export function PasswordStep({disableLogin}: {disableLogin: boolean}) {
   const t = useTranslations('pages.login');
   const [showPassword, setShowPassword] = useState(false);
   const { isSubmitting, isValid } = useFormikContext<LoginFormValues>();
@@ -107,7 +107,7 @@ export function PasswordStep({disableAfterSuccess}: {disableAfterSuccess: boolea
           type="submit"
           variant="contained"
           size="large"
-          disabled={isSubmitting || disableAfterSuccess || !isValid}
+          disabled={isSubmitting || disableLogin || !isValid}
           startIcon={<Login />}
           sx={{
             borderRadius: 3,


### PR DESCRIPTION
Resolves https://github.com/FIRSTIsrael/lems/issues/1475

Formik sets isSubmitting to false as soon as the submission promise resolves or rejects. As a result, the login button becomes enabled, so isSubmitting cannot be used to keep the login button disabled after submission.

This PR adds a disableAfterSuccess flag to manage the disabled state explicitly.

The fix is applied to both the frontend and admin login dialogs
