### PR TITLE
Fix #1398

### DIFF
--- a/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/schedule/components/calendar/calendar-header.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/schedule/components/calendar/calendar-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { mutate } from 'swr';
 import { Box, Stack, Button, CircularProgress } from '@mui/material';
@@ -28,9 +28,15 @@ export const CalendarHeader: React.FC<{ division: Division }> = ({ division }) =
   });
   const [verificationPassed, setVerificationPassed] = useState(false);
 
-  const { addPracticeRound, addRankingRound } = useCalendar();
   const calendarContext = useCalendar();
   const scheduleContext = useSchedule();
+  const { addPracticeRound, addRankingRound } = calendarContext;
+
+  // Disable "Generate" after any schedule/calendar change:
+  useEffect(() => {
+    // Whenever the schedule or calendar context changes, force re‑verify
+    setVerificationPassed(false);
+  }, [calendarContext, scheduleContext]);
 
   const handleVerify = async () => {
     setIsVerifying(true);


### PR DESCRIPTION
## Description

This PR updates the admin schedule UI so that the Generate schedule button is only enabled immediately after a successful validation. Any change to the calendar or schedule now invalidates the previous validation and disables the generate action until the user re‑verifies.
Added a useEffect that resets verificationPassed to false whenever the schedule or calendar context changes.

Closes # 1398

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
