### PR TITLE
Fix #1397 update practice/ranking round counters on field block delete

### DIFF
--- a/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/schedule/components/calendar/calendar-context.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/schedule/components/calendar/calendar-context.tsx
@@ -293,6 +293,15 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children }) 
     }
 
     setBlocks(prev => ({ ...prev, field: newBlocks }));
+
+    // update counters
+    if (deleted.type === 'practice-round') {
+      setPracticeRounds(prevRounds => prevRounds - 1)
+    }
+
+    if (deleted.type === 'ranking-round') {
+      setRankingRounds(prevRounds => prevRounds - 1);
+    }
   };
 
   const addAgendaEvent = (startTime: Dayjs, durationSeconds: number, title: string) => {


### PR DESCRIPTION
## Description

Fix the schedule calendar bug where deleting a practice or ranking round did not correctly update the underlying round counters, which could cause practice/ranking rounds to become inconsistent and mis-numbered.

Closes #1397

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

N/A – behavior change only; UI layout remains the same.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
