### PR TITLE
disabled virtualization on data grid

### DIFF
--- a/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/components/event-teams-unified-view.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/events/[slug]/teams/components/event-teams-unified-view.tsx
@@ -2,10 +2,9 @@
 
 import { useMemo, useState } from 'react';
 import { DataGrid, GridColDef, GridActionsCellItem } from '@mui/x-data-grid';
-import { Avatar, Box, Chip } from '@mui/material';
+import { Avatar, Box, Chip, useTheme } from '@mui/material';
 import { Edit } from '@mui/icons-material';
-import { useLocale, useTranslations } from 'next-intl';
-import { Locale } from '@lems/localization';
+import { useTranslations } from 'next-intl';
 import { TeamWithDivision, Division } from '@lems/types/api/admin';
 import { UnifiedTeamsSearch } from './unified-teams-search';
 import { RemoveTeamButton } from './remove-team-button';
@@ -20,7 +19,7 @@ export const EventTeamsUnifiedView: React.FC<EventTeamsUnifiedViewProps> = ({
   divisions
 }) => {
   const t = useTranslations('pages.events.teams.unified');
-  const currentLocale = useLocale() as Locale;
+  const theme = useTheme();
   const [searchValue, setSearchValue] = useState('');
 
   const hasMultipleDivisions = divisions.length > 1;
@@ -153,7 +152,7 @@ export const EventTeamsUnifiedView: React.FC<EventTeamsUnifiedViewProps> = ({
         <DataGrid
           rows={filteredTeams}
           columns={columns}
-          disableVirtualization={currentLocale === 'he'} // Workaround for MUI issue with RTL virtualization
+          disableVirtualization={theme.direction === 'rtl'} // Workaround for MUI issue with RTL virtualization
           initialState={{
             pagination: {
               paginationModel: { page: 0, pageSize: 50 }

--- a/apps/admin/src/app/[locale]/(dashboard)/teams/components/teams-data-grid.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/teams/components/teams-data-grid.tsx
@@ -3,11 +3,10 @@
 import { useMemo, useState } from 'react';
 import useSWR from 'swr';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { Avatar, Box, Chip } from '@mui/material';
-import { useLocale, useTranslations } from 'next-intl';
+import { Avatar, Box, Chip, useTheme } from '@mui/material';
+import { useTranslations } from 'next-intl';
 import { Team } from '@lems/types/api/admin';
 import { Flag } from '@lems/shared';
-import { Locale } from '@lems/localization';
 import { TeamsSearch } from './teams-search';
 import { DeleteTeamButton } from './delete-team-button';
 import { UpdateTeamButton } from './update-team-button';
@@ -19,7 +18,7 @@ interface TeamsDataGridProps {
 export const TeamsDataGrid: React.FC<TeamsDataGridProps> = ({ teams: initialTeams }) => {
   const t = useTranslations('pages.teams.list');
   const [searchValue, setSearchValue] = useState('');
-  const currentLocale = useLocale() as Locale;
+  const theme = useTheme();
 
   const { data: teams } = useSWR<Team[]>('/admin/teams', {
     fallbackData: initialTeams
@@ -164,7 +163,7 @@ export const TeamsDataGrid: React.FC<TeamsDataGridProps> = ({ teams: initialTeam
         <DataGrid
           rows={filteredTeams}
           columns={columns}
-          disableVirtualization={currentLocale === 'he'} // Workaround for MUI issue with RTL virtualization
+          disableVirtualization={theme.direction === 'rtl'} // Workaround for MUI issue with RTL virtualization
           initialState={{
             pagination: {
               paginationModel: { page: 0, pageSize: 50 }

--- a/apps/admin/src/app/[locale]/(dashboard)/users/components/users-data-grid.tsx
+++ b/apps/admin/src/app/[locale]/(dashboard)/users/components/users-data-grid.tsx
@@ -3,12 +3,11 @@
 import { useMemo, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 import { DataGrid, GridColDef, GridActionsCellItem } from '@mui/x-data-grid';
-import { Avatar, Box } from '@mui/material';
+import { Avatar, Box, useTheme } from '@mui/material';
 import { Edit, Security, Delete } from '@mui/icons-material';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { AdminUser } from '@lems/types/api/admin';
 import { apiFetch } from '@lems/shared';
-import { Locale } from '@lems/localization';
 import { useSession } from '../../components/session-context';
 import { UsersSearch } from './users-search';
 import { PermissionsEditorDialog } from './permissions-editor-dialog';
@@ -31,7 +30,7 @@ interface DialogState {
 export const UsersDataGrid: React.FC<UsersDataGridProps> = ({ users: initialUsers }) => {
   const t = useTranslations('pages.users.list');
   const session = useSession();
-  const currentLocale = useLocale() as Locale;
+  const theme = useTheme();
   const [searchValue, setSearchValue] = useState('');
   const [dialog, setDialog] = useState<DialogState>({
     type: null,
@@ -197,7 +196,7 @@ export const UsersDataGrid: React.FC<UsersDataGridProps> = ({ users: initialUser
         <DataGrid
           rows={filteredUsers}
           columns={columns}
-          disableVirtualization={currentLocale === 'he'} // Workaround for MUI issue with RTL virtualization
+          disableVirtualization={theme.direction === 'rtl'} // Workaround for MUI issue with RTL virtualization
           initialState={{
             pagination: {
               paginationModel: { page: 0, pageSize: 50 }

--- a/apps/portal/src/app/[locale]/event/[slug]/components/tabs/scoreboard/desktop-scoreboard.tsx
+++ b/apps/portal/src/app/[locale]/event/[slug]/components/tabs/scoreboard/desktop-scoreboard.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import React from 'react';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, useTheme } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { ScoreboardEntry } from '@lems/types/api/portal';
-import { Locale } from '@lems/localization';
 
 interface DesktopScoreboardProps {
   sortedData: ScoreboardEntry[];
@@ -20,7 +19,7 @@ export const DesktopScoreboard: React.FC<DesktopScoreboardProps> = ({
   eventSlug
 }) => {
   const t = useTranslations('pages.event');
-  const currentLocale = useLocale() as Locale;
+  const theme = useTheme();
 
   const columns: GridColDef<ScoreboardEntry>[] = [
     {
@@ -78,7 +77,7 @@ export const DesktopScoreboard: React.FC<DesktopScoreboardProps> = ({
         density="compact"
         rows={sortedData}
         columns={columns}
-        disableVirtualization={currentLocale === 'he'} // Workaround for MUI issue with RTL virtualization
+        disableVirtualization={theme.direction === 'rtl'} // Workaround for MUI issue with RTL virtualization
         getRowId={row => row.team.id}
         slots={{
           noRowsOverlay: () => (


### PR DESCRIPTION
## Description

Disabled virtualization for data grid, its mostly helps on large grids but when we are limiting to 100 teams per page it should be ok and it fixes the bug i guess.

Closes #1408 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![ezgif-7646be73dc87a1c4](https://github.com/user-attachments/assets/7ec66877-5767-4db7-8cbd-fb0f32195012)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
