### PR TITLE
long team info breaks ref pre match view

### DIFF
--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/components/team-info.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/components/team-info.tsx
@@ -45,11 +45,11 @@ export const TeamInfo: React.FC<TeamInfoProps> = ({ team, size, textAlign = 'lef
           variant={secondaryTypographyVariantMap[size] as 'caption' | 'body2' | 'h6'}
           color="text.secondary"
           sx={{
-            whiteSpace: 'nowrap',
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
             display: 'flex',
-            gap: 0.5
+            gap: 0.5,
+            flexWrap: 'wrap',
+            alignItems: 'center'
           }}
         >
           {team.region && (


### PR DESCRIPTION
closes #1998

<img width="627" height="867" alt="Screenshot 2026-02-22 at 22 39 29" src="https://github.com/user-attachments/assets/fc418763-de42-4851-bd80-c1fb56e339ee" />

