### PR TITLE
Remove "called" check for sessions swap

### DIFF
--- a/apps/backend/src/lib/graphql/resolvers/mutations/schedule/set-judging-session-team.ts
+++ b/apps/backend/src/lib/graphql/resolvers/mutations/schedule/set-judging-session-team.ts
@@ -48,14 +48,13 @@ async function authorizeTournamentManagerAccess(
  * 1. User has tournament-manager role and access to division
  * 2. Session exists in the division
  * 3. Session is in not-started status
- * 4. Session has not been called yet
- * 5. If teamId is provided, team exists in the division
+ * 4. If teamId is provided, team exists in the division
  */
 export const setJudgingSessionTeamResolver: GraphQLFieldResolver<
   unknown,
   GraphQLContext,
   SetJudgingSessionTeamArgs,
-  Promise<any>
+  Promise<{ id: string }>
 > = async (_root, { divisionId, sessionId, teamId }, context) => {
   try {
     // Authorization
@@ -88,15 +87,7 @@ export const setJudgingSessionTeamResolver: GraphQLFieldResolver<
       );
     }
 
-    // Check 3: Session must not have been called
-    if (sessionState.called) {
-      throw new MutationError(
-        MutationErrorCode.CONFLICT,
-        'Cannot change teams in a session that has been called'
-      );
-    }
-
-    // Check 4: If teamId is provided, team must exist in the division
+    // Check 3: If teamId is provided, team must exist in the division
     if (teamId) {
       const teams = await db.teams.byDivisionId(divisionId).getAll();
       const teamExists = teams.some(t => t.id === teamId);

--- a/apps/backend/src/lib/graphql/resolvers/mutations/schedule/swap-session-teams.ts
+++ b/apps/backend/src/lib/graphql/resolvers/mutations/schedule/swap-session-teams.ts
@@ -49,7 +49,6 @@ async function authorizeTournamentManagerAccess(
  * 2. Both sessions exist in the division
  * 3. Sessions are different
  * 4. Both sessions are in not-started status
- * 5. Neither session is currently called/active
  */
 export const swapSessionTeamsResolver: GraphQLFieldResolver<
   unknown,
@@ -109,14 +108,6 @@ export const swapSessionTeamsResolver: GraphQLFieldResolver<
       throw new MutationError(
         MutationErrorCode.CONFLICT,
         'Both sessions must be in not-started status to swap teams'
-      );
-    }
-
-    // Check 4: Neither session should be currently called
-    if (session1State.called || session2State.called) {
-      throw new MutationError(
-        MutationErrorCode.CONFLICT,
-        'Cannot swap teams in sessions that have been called'
       );
     }
 


### PR DESCRIPTION
## Description

Removed the dependency on not called for session swapping since we call rounds and not individual rooms

Closes #2001

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
