### PR TITLE
Add smooth audience display mode transitions

### DIFF
--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/display-mode-transition.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/display-mode-transition.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+import { AudienceDisplayScreen } from '../graphql/types';
+
+interface DisplayModeTransitionProps {
+  activeDisplay: AudienceDisplayScreen;
+  children: (display: AudienceDisplayScreen) => ReactNode;
+}
+
+export const DisplayModeTransition = ({ activeDisplay, children }: DisplayModeTransitionProps) => {
+  return (
+    <AnimatePresence initial={false}>
+      <motion.div
+        key={activeDisplay}
+        initial={{ opacity: 0, scale: 1.02 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.98 }}
+        transition={{ duration: 0.45, ease: 'easeInOut' }}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%'
+        }}
+      >
+        {children(activeDisplay)}
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/match-preview/match-preview-display.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/match-preview/match-preview-display.tsx
@@ -79,8 +79,7 @@ export const MatchPreviewDisplay = () => {
           maxWidth: '1800px',
           p: 6,
           bgcolor: theme => alpha(theme.palette.background.paper, 0.98),
-          borderRadius: 2,
-          animation: 'fadeInScale 0.6s ease-out'
+          borderRadius: 2
         }}
       >
         <Stack
@@ -180,7 +179,6 @@ export const MatchPreviewDisplay = () => {
             spacing={2}
             columns={columns}
             sx={{
-              animation: 'fadeIn 0.8s ease-out',
               justifyContent: 'center'
             }}
           >
@@ -190,27 +188,6 @@ export const MatchPreviewDisplay = () => {
           </Grid>
         </Stack>
       </Box>
-      <style>{`
-        @keyframes fadeInScale {
-          0% {
-            opacity: 0;
-            transform: scale(0.98);
-          }
-          100% {
-            opacity: 1;
-            transform: scale(1);
-          }
-        }
-
-        @keyframes fadeIn {
-          0% {
-            opacity: 0;
-          }
-          100% {
-            opacity: 1;
-          }
-        }
-      `}</style>
     </Box>
   );
 };

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/message-display.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/message-display.tsx
@@ -49,26 +49,12 @@ export const MessageDisplay = () => {
             color: '#000',
             textShadow: '0 2px 8px rgba(255, 255, 255, 0.5)',
             lineHeight: 1.2,
-            wordWrap: 'break-word',
-            animation: 'fadeInScale 0.8s ease-out'
+            wordWrap: 'break-word'
           }}
         >
           {message}
         </Typography>
       </Box>
-
-      <style>{`
-        @keyframes fadeInScale {
-          0% {
-            opacity: 0;
-            transform: scale(0.95);
-          }
-          100% {
-            opacity: 1;
-            transform: scale(1);
-          }
-        }
-      `}</style>
     </Box>
   );
 };

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/scoreboard/scoreboard-display.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/scoreboard/scoreboard-display.tsx
@@ -81,8 +81,7 @@ export const ScoreboardDisplay = () => {
           sx={{
             maxWidth: '80vw',
             height: '90%',
-            width: '100%',
-            animation: 'fadeIn 0.6s ease-out'
+            width: '100%'
           }}
         >
           {(scoreboardSettings?.showActiveMatch as boolean) && <ActiveMatch />}
@@ -90,17 +89,6 @@ export const ScoreboardDisplay = () => {
           <ScoresTable />
           {(scoreboardSettings?.showSponsorsRow as boolean) && <SponsorsRow />}
         </Stack>
-
-        <style>{`
-        @keyframes fadeIn {
-          0% {
-            opacity: 0;
-          }
-          100% {
-            opacity: 1;
-          }
-        }
-      `}</style>
       </Box>
     </ScoreboardProvider>
   );

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/sponsors-display.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/components/sponsors-display.tsx
@@ -55,8 +55,7 @@ export const SponsorsDisplay = () => {
           width: '90%',
           maxWidth: '1200px',
           pt: '10vh',
-          height: '40vh',
-          animation: 'fadeInScale 0.5s ease-out'
+          height: '40vh'
         }}
       >
         <Image
@@ -72,28 +71,6 @@ export const SponsorsDisplay = () => {
           }}
         />
       </Box>
-
-      <style>{`
-        @keyframes fadeIn {
-          0% {
-            opacity: 0;
-          }
-          100% {
-            opacity: 1;
-          }
-        }
-
-        @keyframes fadeInScale {
-          0% {
-            opacity: 0;
-            transform: scale(0.98);
-          }
-          100% {
-            opacity: 1;
-            transform: scale(1);
-          }
-        }
-      `}</style>
     </Box>
   );
 };

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/page.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/audience-display/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { Box } from '@mui/material';
 import { useEvent } from '../components/event-context';
 import useKeyboardShortcut from '../hooks/use-keyboard-shortcut';
 import { usePageData } from '../hooks/use-page-data';
@@ -12,6 +13,7 @@ import { MatchPreviewDisplay } from './components/match-preview/match-preview-di
 import { ScoreboardDisplay } from './components/scoreboard/scoreboard-display';
 import { AwardsDisplay } from './components/awards/awards-display';
 import { SettingsModal } from './components/settings';
+import { DisplayModeTransition } from './components/display-mode-transition';
 import {
   createAudienceDisplaySettingUpdatedSubscription,
   createAudienceDisplaySwitchedSubscription,
@@ -117,20 +119,36 @@ export default function AudienceDisplayPage() {
         awards={data.awards}
         awardsAssigned={data.awardsAssigned}
       >
-        {activeDisplay === 'logo' && <LogoDisplay />}
-        {activeDisplay === 'message' && <MessageDisplay />}
-        {activeDisplay === 'sponsors' && <SponsorsDisplay />}
-        {activeDisplay === 'match_preview' && <MatchPreviewDisplay />}
-        {activeDisplay === 'scoreboard' && <ScoreboardDisplay />}
-        {activeDisplay === 'awards' && (
-          <AwardsDisplay
-            awards={data.awards}
-            awardWinnerSlideStyle={
-              (data.displayState.settings?.awards?.awardWinnerSlideStyle as
-                'chroma' | 'full' | 'both') || 'both'
-            }
-          />
-        )}
+        <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
+          <DisplayModeTransition activeDisplay={activeDisplay}>
+            {display => {
+              switch (display) {
+                case 'logo':
+                  return <LogoDisplay />;
+                case 'message':
+                  return <MessageDisplay />;
+                case 'sponsors':
+                  return <SponsorsDisplay />;
+                case 'match_preview':
+                  return <MatchPreviewDisplay />;
+                case 'scoreboard':
+                  return <ScoreboardDisplay />;
+                case 'awards':
+                  return (
+                    <AwardsDisplay
+                      awards={data.awards}
+                      awardWinnerSlideStyle={
+                        (data.displayState.settings?.awards?.awardWinnerSlideStyle as
+                          | 'chroma'
+                          | 'full'
+                          | 'both') || 'both'
+                      }
+                    />
+                  );
+              }
+            }}
+          </DisplayModeTransition>
+        </Box>
       </AudienceDisplayProvider>
       <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
     </>


### PR DESCRIPTION
## Description

Adds smooth crossfade transitions when the scorekeeper switches between audience display modes (logo, message, sponsors, match preview, scoreboard, awards). A new `DisplayModeTransition` component uses `motion/react` to animate opacity and scale between modes, and redundant per-mode mount fade animations were removed to avoid double-fading.

Closes #1993

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

N/A — transition is best verified live on the audience display page.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings