### PR TITLE
fix: awards presentation previews in RTL (#1967)

### DIFF
--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/scorekeeper/components/awards-presentation/slide-display.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/scorekeeper/components/awards-presentation/slide-display.tsx
@@ -57,7 +57,16 @@ export const SlideDisplay: React.FC<SlideDisplayProps> = ({
           transition: 'box-shadow 0.3s ease'
         }}
       >
-        <div style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}>
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column'
+          }}
+        >
           <Deck ref={deckRef} initialState={initialState} enableReinitialize={true}>
             {awardSlides}
           </Deck>

--- a/libs/presentations/src/lib/components/deck.tsx
+++ b/libs/presentations/src/lib/components/deck.tsx
@@ -148,7 +148,10 @@ export const Deck = forwardRef<DeckRef, DeckProps>(
           cancelTransition
         }}
       >
-        <div ref={setSlidePortalNode}></div>
+        <div
+          ref={setSlidePortalNode}
+          style={{ position: 'relative', width: '100%', height: '100%', flex: 1, minHeight: 0 }}
+        />
         <div ref={setPlaceholderContainer} style={{ display: 'none' }}>
           {children}
         </div>

--- a/libs/presentations/src/lib/components/logo-stack.tsx
+++ b/libs/presentations/src/lib/components/logo-stack.tsx
@@ -17,7 +17,7 @@ export const LogoStack: React.FC<LogoStackProps> = ({ color }) => {
         alignItems: 'center',
         position: 'absolute',
         bottom: 0,
-        left: 0,
+        insetInlineStart: 0,
         width: '100%',
         height: '100px',
         bgcolor: '#f7f8f9',

--- a/libs/presentations/src/lib/components/slide-scaler.tsx
+++ b/libs/presentations/src/lib/components/slide-scaler.tsx
@@ -14,18 +14,29 @@ export const SlideScaler: React.FC<SlideScalerProps> = ({ children, ...props }) 
 
   const ref = useRef(null);
   const { width, height } = useDimensions(ref);
+  const scale = Math.min(width / DEFAULT_WIDTH, height / DEFAULT_HEIGHT) || 0;
 
   return (
-    <Box ref={ref} {...props} sx={{ width: '100%', height: '100%' }}>
+    <Box
+      ref={ref}
+      {...props}
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+        ...props.sx
+      }}
+    >
       <div
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: DEFAULT_HEIGHT,
           width: DEFAULT_WIDTH,
-          transform: `scale(${Math.max(width / DEFAULT_WIDTH, height / DEFAULT_HEIGHT)})`,
-          transformOrigin: 'top left'
+          height: DEFAULT_HEIGHT,
+          transform: `scale(${scale})`,
+          transformOrigin: 'center center',
+          flexShrink: 0
         }}
       >
         {children}

--- a/libs/presentations/src/lib/components/slide.tsx
+++ b/libs/presentations/src/lib/components/slide.tsx
@@ -129,8 +129,8 @@ export const Slide: React.FC<SlideProps> = ({
               style={{
                 display: isActive ? 'unset' : 'none',
                 position: 'absolute',
+                insetInlineStart: 0,
                 top: 0,
-                left: 0,
                 height: '100%',
                 width: '100%',
                 backgroundImage: chromaKey

--- a/libs/presentations/src/lib/components/slides/award-winner-chroma-slide.tsx
+++ b/libs/presentations/src/lib/components/slides/award-winner-chroma-slide.tsx
@@ -53,77 +53,79 @@ const AwardWinnerChromaSlide: React.FC<AwardWinnerChromaSlideProps> = ({ award }
 
   return (
     <Slide chromaKey>
-      <Box
-        sx={{
-          background: '#f7f8f9',
-          width: '85%',
-          px: 6,
-          py: 2,
-          borderRadius: 4,
-          textAlign: 'center',
-          position: 'absolute',
-          bottom: 60,
-          borderWidth: '0 0 10px 10px',
-          borderStyle: 'solid',
-          borderColor: award.divisionColor ? award.divisionColor : undefined
-        }}
-      >
-        <Typography variant="h2" sx={{ fontSize: '2.5rem', fontWeight: 700, color: 'black' }}>
-          {localizedAwardName} {award.place && `| ${t('place', { place: award.place })}`}
-        </Typography>
-        <Appear activeStyle={{ opacity: 1, scale: 1 }} inactiveStyle={{ opacity: 0, scale: 0.95 }}>
-          <Stack direction="column" spacing={1}>
-            {isTeamWinner ? (
-              <>
-                <Stack
-                  direction="row"
-                  spacing={2}
-                  sx={{
-                    alignItems: 'center',
-                    justifyContent: 'center'
-                  }}
-                >
-                  <Box
+      <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
+        <Box
+          sx={{
+            background: '#f7f8f9',
+            width: '85%',
+            px: 6,
+            py: 2,
+            borderRadius: 4,
+            textAlign: 'center',
+            position: 'absolute',
+            bottom: 60,
+            insetInlineStart: 0,
+            insetInlineEnd: 0,
+            marginInline: 'auto',
+            borderBlockEnd: award.divisionColor ? `10px solid ${award.divisionColor}` : undefined,
+            borderInlineStart: award.divisionColor ? `10px solid ${award.divisionColor}` : undefined
+          }}
+        >
+          <Typography variant="h2" sx={{ fontSize: '2.5rem', fontWeight: 700, color: 'black' }}>
+            {localizedAwardName} {award.place && `| ${t('place', { place: award.place })}`}
+          </Typography>
+          <Appear activeStyle={{ opacity: 1, scale: 1 }} inactiveStyle={{ opacity: 0, scale: 0.95 }}>
+            <Stack direction="column" spacing={1}>
+              {isTeamWinner ? (
+                <>
+                  <Stack
+                    direction="row"
+                    spacing={2}
                     sx={{
-                      flexShrink: 0,
-                      width: 120,
-                      height: 120,
-                      position: 'relative',
-                      overflow: 'hidden'
+                      alignItems: 'center',
+                      justifyContent: 'center'
                     }}
                   >
-                    <Image
-                      src={
-                        (winner as TeamWinner).logoUrl
-                          ? ((winner as TeamWinner).logoUrl as string)
-                          : '/assets/default-avatar.svg'
-                      }
-                      alt={(winner as TeamWinner).name}
-                      fill
-                      style={{ objectFit: 'contain', padding: 8 }}
-                    />
-                  </Box>
-                  <Typography
-                    sx={{
-                      fontSize: '3.5rem',
-                      fontWeight: 800,
-                      color: award.divisionColor || 'primary.main',
-                      letterSpacing: '-0.02em'
-                    }}
-                  >
-                    {(winner as TeamWinner).name} #{(winner as TeamWinner).number}
-                  </Typography>
-                </Stack>
-                {(winner as TeamWinner).affiliation && (
-                  <Typography
-                    sx={{ fontSize: '1.75rem', color: 'text.secondary', fontWeight: 600 }}
-                  >
-                    {(winner as TeamWinner).affiliation}, {(winner as TeamWinner).city}
-                  </Typography>
-                )}
-              </>
-            ) : (
-              <>
+                    <Box
+                      sx={{
+                        flexShrink: 0,
+                        width: 120,
+                        height: 120,
+                        position: 'relative',
+                        overflow: 'hidden'
+                      }}
+                    >
+                      <Image
+                        src={
+                          (winner as TeamWinner).logoUrl
+                            ? ((winner as TeamWinner).logoUrl as string)
+                            : '/assets/default-avatar.svg'
+                        }
+                        alt={(winner as TeamWinner).name}
+                        fill
+                        style={{ objectFit: 'contain', padding: 8 }}
+                      />
+                    </Box>
+                    <Typography
+                      sx={{
+                        fontSize: '3.5rem',
+                        fontWeight: 800,
+                        color: award.divisionColor || 'primary.main',
+                        letterSpacing: '-0.02em'
+                      }}
+                    >
+                      {(winner as TeamWinner).name} #{(winner as TeamWinner).number}
+                    </Typography>
+                  </Stack>
+                  {(winner as TeamWinner).affiliation && (
+                    <Typography
+                      sx={{ fontSize: '1.75rem', color: 'text.secondary', fontWeight: 600 }}
+                    >
+                      {(winner as TeamWinner).affiliation}, {(winner as TeamWinner).city}
+                    </Typography>
+                  )}
+                </>
+              ) : (
                 <Typography
                   sx={{
                     fontSize: '5rem',
@@ -134,24 +136,26 @@ const AwardWinnerChromaSlide: React.FC<AwardWinnerChromaSlideProps> = ({ award }
                 >
                   {(winner as PersonalWinner).name}
                 </Typography>
-              </>
-            )}
-          </Stack>
-        </Appear>
-        <Image
-          src="/assets/audience-display/sponsors/first-horizontal.svg"
-          alt="תמונת ספונסר"
-          width={250}
-          height={100}
-          style={{ position: 'fixed', left: 1920 - 250 - 180, bottom: 80 }}
-        />
-        <Image
-          src="/assets/audience-display/season-logo.svg"
-          alt="תמונת ספונסר"
-          width={250}
-          height={100}
-          style={{ position: 'fixed', left: 180, bottom: 80 }}
-        />
+              )}
+            </Stack>
+          </Appear>
+        </Box>
+        <Box sx={{ position: 'absolute', insetInlineStart: 180, bottom: 80 }}>
+          <Image
+            src="/assets/audience-display/season-logo.svg"
+            alt="תמונת ספונסר"
+            width={250}
+            height={100}
+          />
+        </Box>
+        <Box sx={{ position: 'absolute', insetInlineEnd: 180, bottom: 80 }}>
+          <Image
+            src="/assets/audience-display/sponsors/first-horizontal.svg"
+            alt="תמונת ספונסר"
+            width={250}
+            height={100}
+          />
+        </Box>
       </Box>
     </Slide>
   );


### PR DESCRIPTION
## Summary
- Fix scorekeeper awards slide previews in Hebrew by giving the deck slide portal full dimensions and centering embedded slide scaling
- Make presentation slides RTL-aware with logical positioning on slide portals, logo stack, and chroma slide sponsor logos
- Center the chroma slide awards panel and replace viewport-fixed sponsor logos with slide-relative absolute positioning

Fixes #1967

## Test plan
- [ ] Open scorekeeper in Hebrew (`/he/.../scorekeeper`), switch audience display to Awards
- [ ] Verify current and next slide previews render inside the 16:9 boxes (no clipping or empty panes)
- [ ] Advance slides and confirm Appear animations show team/winner details on chroma slides
- [ ] Confirm chroma slide sponsor logos appear in the correct corners
- [ ] Repeat in English (`/en/...`) to confirm no regression
- [ ] Verify audience display awards mode still renders correctly in Hebrew fullscreen
