### PR TITLE
Hide Blocked Teams Behind a Toggle

### DIFF
--- a/apps/frontend/locale/en.json
+++ b/apps/frontend/locale/en.json
@@ -707,7 +707,9 @@
           "session": "Session #",
           "sessions": "Sessions",
           "results": "Results",
-          "clear": "Clear Filters"
+          "clear": "Clear Filters",
+          "show-blocked": "Show Blocked",
+          "hide-blocked": "Hide Blocked"
         },
         "sort": {
           "room": "Sort by Room",
@@ -1278,7 +1280,9 @@
           "session": "Session #",
           "sessions": "Sessions",
           "results": "Results",
-          "clear": "Clear Filters"
+          "clear": "Clear Filters",
+          "show-blocked": "Show Blocked",
+          "hide-blocked": "Hide Blocked"
         },
         "sort": {
           "room": "Sort by Room",

--- a/apps/frontend/locale/he.json
+++ b/apps/frontend/locale/he.json
@@ -705,7 +705,9 @@
           "session": "סבב #",
           "sessions": "סבבים",
           "results": "תוצאות",
-          "clear": "נקה מסננים"
+          "clear": "נקה מסננים",
+          "show-blocked": "הצג פסלות",
+          "hide-blocked": "הסתר פסלות"
         },
         "sort": {
           "room": "מיין לפי חדר",
@@ -1276,7 +1278,9 @@
           "session": "סבב #",
           "sessions": "סבבים",
           "results": "תוצאות",
-          "clear": "נקה מסננים"
+          "clear": "נקה מסננים",
+          "show-blocked": "הצג פסולות",
+          "hide-blocked": "הסתר פסולות"
         },
         "sort": {
           "room": "מיין לפי חדר",

--- a/apps/frontend/locale/pl.json
+++ b/apps/frontend/locale/pl.json
@@ -707,7 +707,9 @@
           "session": "Sesja #",
           "sessions": "Sesje",
           "results": "Wyniki",
-          "clear": "Wyczyść filtry"
+          "clear": "Wyczyść filtry",
+          "show-blocked": "Pokaż zablokowane",
+          "hide-blocked": "Ukryj zablokowane"
         },
         "sort": {
           "room": "Sortuj wg sali",
@@ -1277,7 +1279,9 @@
           "session": "Sesja #",
           "sessions": "Sesje",
           "results": "Wyniki",
-          "clear": "Wyczyść filtry"
+          "clear": "Wyczyść filtry",
+          "show-blocked": "Pokaż zablokowane",
+          "hide-blocked": "Ukryj zablokowane"
         },
         "sort": {
           "room": "Sortuj wg sali",

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/disqualification/disqualification-section.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/disqualification/disqualification-section.tsx
@@ -2,14 +2,17 @@
 
 import { useMemo, useState, useCallback } from 'react';
 import toast from 'react-hot-toast';
-import { Card, CardContent, CardHeader, Stack, useTheme } from '@mui/material';
+import { Card, CardContent, CardHeader, Stack, useTheme, Button, Tooltip } from '@mui/material';
 import { useMutation } from '@apollo/client/react';
 import { useTranslations } from 'next-intl';
 import SearchIcon from '@mui/icons-material/Search';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import type { Team } from '../../graphql/types';
 import { DISQUALIFY_TEAM } from '../../graphql/mutations/disqualify-team';
 import { useEvent } from '../../../../components/event-context';
 import { useJudgeAdvisor } from '../judge-advisor-context';
+import { useFilters } from '../filters-context';
 import { DisqualifyConfirmationDialog } from './disqualify-confirmation-dialog';
 import { SearchTeamSection } from './search-team-section';
 import { SelectedTeamPreview } from './selected-team-preview';
@@ -17,9 +20,11 @@ import { DisqualifiedTeamsList } from './disqualified-teams-list';
 
 export function DisqualificationSection() {
   const t = useTranslations('pages.judge-advisor.awards.disqualification');
+  const tGrid = useTranslations('pages.judge-advisor.grid');
   const theme = useTheme();
   const { currentDivision } = useEvent();
   const { sessions, disqualifiedTeams, loading } = useJudgeAdvisor();
+  const { showBlocked, setShowBlocked } = useFilters();
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
 
@@ -71,6 +76,21 @@ export function DisqualificationSection() {
           title={t('search-title')}
           avatar={<SearchIcon sx={{ color: 'primary.main' }} />}
           slotProps={{ title: { variant: 'h6', sx: { fontWeight: 600 } } }}
+          action={
+            <Tooltip
+              title={showBlocked ? tGrid('filter.hide-blocked') : tGrid('filter.show-blocked')}
+            >
+              <Button
+                size="small"
+                variant={showBlocked ? 'contained' : 'outlined'}
+                onClick={() => setShowBlocked(!showBlocked)}
+                startIcon={showBlocked ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                sx={{ whiteSpace: 'nowrap' }}
+              >
+                {showBlocked ? tGrid('filter.hide-blocked') : tGrid('filter.show-blocked')}
+              </Button>
+            </Tooltip>
+          }
         />
         <CardContent>
           <Stack spacing={2.5}>

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/disqualification/disqualified-teams-list.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/disqualification/disqualified-teams-list.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import BlockIcon from '@mui/icons-material/Block';
 import type { Team } from '../../graphql/types';
 import { TeamInfo } from '../../../components/team-info';
+import { useFilters } from '../filters-context';
 
 interface DisqualifiedTeamsListProps {
   disqualifiedTeams: Team[];
@@ -13,8 +14,9 @@ interface DisqualifiedTeamsListProps {
 export function DisqualifiedTeamsList({ disqualifiedTeams }: DisqualifiedTeamsListProps) {
   const t = useTranslations('pages.judge-advisor.awards.disqualification');
   const theme = useTheme();
+  const { showBlocked } = useFilters();
 
-  if (disqualifiedTeams.length === 0) {
+  if (disqualifiedTeams.length === 0 || !showBlocked) {
     return null;
   }
 

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/filters-context.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/filters-context.tsx
@@ -14,6 +14,8 @@ interface FiltersContextType {
   setSessionNumberFilter: (value: number[]) => void;
   sortBy: 'room' | 'session';
   setSortBy: (value: 'room' | 'session') => void;
+  showBlocked: boolean;
+  setShowBlocked: (value: boolean) => void;
   clearFilters: () => void;
 }
 
@@ -43,6 +45,7 @@ export const FiltersProvider: React.FC<FiltersProviderProps> = ({ children }) =>
         .map(s => parseInt(s, 10))
     : [];
   const sortBy = (searchParams.get('sortBy') || 'room') as 'room' | 'session';
+  const showBlocked = searchParams.get('showBlocked') === 'true';
 
   const updateUrl = useCallback(
     (updates: Partial<FiltersContextType>) => {
@@ -82,6 +85,14 @@ export const FiltersProvider: React.FC<FiltersProviderProps> = ({ children }) =>
 
       if ('sortBy' in updates && updates.sortBy) {
         newParams.set('sortBy', updates.sortBy);
+      }
+
+      if ('showBlocked' in updates) {
+        if (updates.showBlocked) {
+          newParams.set('showBlocked', 'true');
+        } else {
+          newParams.delete('showBlocked');
+        }
       }
 
       const queryString = newParams.toString();
@@ -125,6 +136,13 @@ export const FiltersProvider: React.FC<FiltersProviderProps> = ({ children }) =>
     [updateUrl]
   );
 
+  const setShowBlocked = useCallback(
+    (value: boolean) => {
+      updateUrl({ showBlocked: value });
+    },
+    [updateUrl]
+  );
+
   const clearFilters = useCallback(() => {
     router.push('?');
   }, [router]);
@@ -140,6 +158,8 @@ export const FiltersProvider: React.FC<FiltersProviderProps> = ({ children }) =>
     setSessionNumberFilter,
     sortBy,
     setSortBy,
+    showBlocked,
+    setShowBlocked,
     clearFilters
   };
 

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/rubric-status-grid.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/rubric-status-grid.tsx
@@ -23,6 +23,8 @@ import {
 } from '@mui/material';
 import { Verified } from '@mui/icons-material';
 import FilterAltOffIcon from '@mui/icons-material/FilterAltOff';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { JUDGING_CATEGORIES } from '@lems/types/judging';
 import { useJudgingCategoryTranslations } from '@lems/localization';
 import { hyphensToUnderscores } from '@lems/shared/utils';
@@ -51,6 +53,8 @@ export const RubricStatusGrid = () => {
     setSessionNumberFilter,
     sortBy,
     setSortBy,
+    showBlocked,
+    setShowBlocked,
     clearFilters
   } = useFilters();
 
@@ -179,6 +183,17 @@ export const RubricStatusGrid = () => {
               {t('sort.session')}
             </Button>
           </ButtonGroup>
+          <Tooltip title={showBlocked ? t('filter.hide-blocked') : t('filter.show-blocked')}>
+            <Button
+              size="small"
+              variant={showBlocked ? 'contained' : 'outlined'}
+              onClick={() => setShowBlocked(!showBlocked)}
+              startIcon={showBlocked ? <VisibilityIcon /> : <VisibilityOffIcon />}
+              sx={{ whiteSpace: 'nowrap' }}
+            >
+              {showBlocked ? t('filter.hide-blocked') : t('filter.show-blocked')}
+            </Button>
+          </Tooltip>
           <Tooltip title={t('filter.clear')}>
             <span>
               <IconButton

--- a/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/team-info-cell.tsx
+++ b/apps/frontend/src/app/[locale]/lems/(volunteer)/(dashboard)/judge-advisor/components/team-info-cell.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl';
 import { Team } from '../graphql';
 import { TeamInfo } from '../../components/team-info';
 import { useJudgeAdvisor } from './judge-advisor-context';
+import { useFilters } from './filters-context';
 
 interface TeamInfoCellProps {
   team: Team;
@@ -15,12 +16,13 @@ interface TeamInfoCellProps {
 export const TeamInfoCell: React.FC<TeamInfoCellProps> = ({ team }) => {
   const t = useTranslations('pages.judge-advisor.team-info-cell');
   const { disqualifiedTeams } = useJudgeAdvisor();
+  const { showBlocked } = useFilters();
   const isDisqualified = disqualifiedTeams.has(team.id);
 
   return (
     <Stack spacing={1} sx={{ minWidth: 200 }}>
       <TeamInfo team={team} size="sm" />
-      {isDisqualified && (
+      {isDisqualified && showBlocked && (
         <Chip
           icon={<BlockIcon />}
           label={t('disqualified')}


### PR DESCRIPTION
## Description

Hide Blocked Teams Behind a Toggle in the Judge advisor Judging and awards tab

Closes #1961

### Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


## Screenshots

<img width="1476" height="252" alt="Screenshot 2026-08-19 at 14 13 56" src="https://github.com/user-attachments/assets/7e103b4a-d801-4529-88f4-a1043a6a20a0" />
<img width="1476" height="252" alt="Screenshot 2026-08-19 at 14 14 00" src="https://github.com/user-attachments/assets/3389a59e-26d2-4b65-83b6-3acd16c15c7b" />
<img width="451" height="273" alt="Screenshot 2026-08-19 at 14 13 41" src="https://github.com/user-attachments/assets/5b322487-8b76-4d8d-b8d1-52cf65381421" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
